### PR TITLE
feat: add support for cdevents 0.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "cdevents-specs/main"]
 	path = cdevents-specs/main
 	url = https://github.com/cdevents/spec.git
+[submodule "cdevents-specs/spec-v0.4"]
+	path = cdevents-specs/spec-v0.4
+	url = https://github.com/cdevents/spec.git
+	branch = spec-v0.4

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ test:
 	cargo nextest run --all-features
 	cargo test --doc
 
+# buid_cdevents-specs:
+# 	git submodule deinit -f --all
+# 	git submodule init
+# 	git submodule add -f https://github.com/cdevents/spec.git cdevents-specs/main
+# 	git submodule add -f -b spec-v0.3 https://github.com/cdevents/spec.git cdevents-specs/spec-v0.3
+# 	git submodule add -f -b spec-v0.4 https://github.com/cdevents/spec.git cdevents-specs/spec-v0.4
+# 	git submodule update -f --rebase -- cdevents-specs/main
+
 .PHONY:
 	generate \
 	check check_no_uncommitted_changes_on_sdk \

--- a/cdevents-sdk/Cargo.toml
+++ b/cdevents-sdk/Cargo.toml
@@ -24,6 +24,7 @@ assert-json-diff = "2.0"
 boon = "0.6"
 glob = "0.3"
 proptest = "1"
+regex = "1.10"
 rstest = "0.21"
 
 [features]

--- a/cdevents-sdk/Cargo.toml
+++ b/cdevents-sdk/Cargo.toml
@@ -25,7 +25,7 @@ boon = "0.6"
 glob = "0.3"
 proptest = "1"
 regex = "1.10"
-rstest = "0.21"
+rstest = "0.22"
 
 [features]
 default = ["cloudevents"]

--- a/cdevents-sdk/src/context.rs
+++ b/cdevents-sdk/src/context.rs
@@ -14,7 +14,7 @@ pub(crate) struct Context {
     pub(crate) timestamp: time::OffsetDateTime,
     #[serde(rename = "schemaUri", skip_serializing_if = "Option::is_none")]
     pub(crate) schema_uri: Option<Uri>,
-    #[serde(rename = "chain_id", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "chainId", skip_serializing_if = "Option::is_none")]
     pub(crate) chain_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) links: Option<serde_json::Value>,

--- a/cdevents-sdk/src/context.rs
+++ b/cdevents-sdk/src/context.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{Id, UriReference};
+use crate::{Id, Uri, UriReference};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -12,6 +12,12 @@ pub(crate) struct Context {
     pub(crate) ty: String,
     #[serde(with = "crate::serde::datetime")]
     pub(crate) timestamp: time::OffsetDateTime,
+    #[serde(rename = "schemaUri", skip_serializing_if = "Option::is_none")]
+    pub(crate) schema_uri: Option<Uri>,
+    #[serde(rename = "chain_id", skip_serializing_if = "Option::is_none")]
+    pub(crate) chain_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) links: Option<serde_json::Value>,
 }
 
 impl Default for Context {
@@ -22,6 +28,9 @@ impl Default for Context {
             source: "/undef".try_into().expect("/undef is a valid uri-reference"),
             ty: "dev.cdevents.undef.undef.0.0.0".into(),
             timestamp: time::OffsetDateTime::now_utc(),
+            schema_uri: None,
+            chain_id: None,
+            links: None,
         }
     }
 }

--- a/cdevents-sdk/src/generated/artifact_deleted_0_1_0.rs
+++ b/cdevents-sdk/src/generated/artifact_deleted_0_1_0.rs
@@ -1,0 +1,29 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "user", default, skip_serializing_if = "Option::is_none",)]
+    pub user: Option<crate::NonEmptyString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/artifact_downloaded_0_1_0.rs
+++ b/cdevents-sdk/src/generated/artifact_downloaded_0_1_0.rs
@@ -1,0 +1,29 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "user", default, skip_serializing_if = "Option::is_none",)]
+    pub user: Option<crate::NonEmptyString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/artifact_packaged_0_2_0.rs
+++ b/cdevents-sdk/src/generated/artifact_packaged_0_2_0.rs
@@ -1,0 +1,49 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "change",)]
+    pub change: ContentChange,
+    #[serde(rename = "sbom", default, skip_serializing_if = "Option::is_none",)]
+    pub sbom: Option<ContentSbom>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentSbom {
+    #[serde(rename = "uri",)]
+    pub uri: crate::UriReference,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentChange {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/artifact_published_0_2_0.rs
+++ b/cdevents-sdk/src/generated/artifact_published_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "sbom", default, skip_serializing_if = "Option::is_none",)]
+    pub sbom: Option<ContentSbom>,
+    #[serde(rename = "user", default, skip_serializing_if = "Option::is_none",)]
+    pub user: Option<crate::NonEmptyString>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentSbom {
+    #[serde(rename = "uri",)]
+    pub uri: crate::UriReference,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/artifact_signed_0_2_0.rs
+++ b/cdevents-sdk/src/generated/artifact_signed_0_2_0.rs
@@ -1,0 +1,29 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "signature",)]
+    pub signature: crate::NonEmptyString,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/branch_created_0_2_0.rs
+++ b/cdevents-sdk/src/generated/branch_created_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/branch_deleted_0_2_0.rs
+++ b/cdevents-sdk/src/generated/branch_deleted_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/build_finished_0_2_0.rs
+++ b/cdevents-sdk/src/generated/build_finished_0_2_0.rs
@@ -1,0 +1,29 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId", default, skip_serializing_if = "Option::is_none",)]
+    pub artifact_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/build_queued_0_2_0.rs
+++ b/cdevents-sdk/src/generated/build_queued_0_2_0.rs
@@ -1,0 +1,27 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/build_started_0_2_0.rs
+++ b/cdevents-sdk/src/generated/build_started_0_2_0.rs
@@ -1,0 +1,27 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/change_abandoned_0_2_0.rs
+++ b/cdevents-sdk/src/generated/change_abandoned_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/change_created_0_3_0.rs
+++ b/cdevents-sdk/src/generated/change_created_0_3_0.rs
@@ -1,0 +1,41 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "description", default, skip_serializing_if = "Option::is_none",)]
+    pub description: Option<crate::NonEmptyString>,
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/change_merged_0_2_0.rs
+++ b/cdevents-sdk/src/generated/change_merged_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/change_reviewed_0_2_0.rs
+++ b/cdevents-sdk/src/generated/change_reviewed_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/change_updated_0_2_0.rs
+++ b/cdevents-sdk/src/generated/change_updated_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "repository", default, skip_serializing_if = "Option::is_none",)]
+    pub repository: Option<ContentRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentRepository {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/environment_created_0_2_0.rs
+++ b/cdevents-sdk/src/generated/environment_created_0_2_0.rs
@@ -1,0 +1,31 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/environment_deleted_0_2_0.rs
+++ b/cdevents-sdk/src/generated/environment_deleted_0_2_0.rs
@@ -1,0 +1,29 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/environment_modified_0_2_0.rs
+++ b/cdevents-sdk/src/generated/environment_modified_0_2_0.rs
@@ -1,0 +1,31 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/incident_detected_0_2_0.rs
+++ b/cdevents-sdk/src/generated/incident_detected_0_2_0.rs
@@ -1,0 +1,55 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId", default, skip_serializing_if = "Option::is_none",)]
+    pub artifact_id: Option<crate::Id>,
+    #[serde(rename = "description", default, skip_serializing_if = "Option::is_none",)]
+    pub description: Option<String>,
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "service", default, skip_serializing_if = "Option::is_none",)]
+    pub service: Option<ContentService>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentService {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/incident_reported_0_2_0.rs
+++ b/cdevents-sdk/src/generated/incident_reported_0_2_0.rs
@@ -1,0 +1,57 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId", default, skip_serializing_if = "Option::is_none",)]
+    pub artifact_id: Option<crate::Id>,
+    #[serde(rename = "description", default, skip_serializing_if = "Option::is_none",)]
+    pub description: Option<String>,
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "service", default, skip_serializing_if = "Option::is_none",)]
+    pub service: Option<ContentService>,
+    #[serde(rename = "ticketURI",)]
+    pub ticket_uri: crate::Uri,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentService {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/incident_resolved_0_2_0.rs
+++ b/cdevents-sdk/src/generated/incident_resolved_0_2_0.rs
@@ -1,0 +1,55 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId", default, skip_serializing_if = "Option::is_none",)]
+    pub artifact_id: Option<crate::Id>,
+    #[serde(rename = "description", default, skip_serializing_if = "Option::is_none",)]
+    pub description: Option<String>,
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "service", default, skip_serializing_if = "Option::is_none",)]
+    pub service: Option<ContentService>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentService {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/mod.rs
+++ b/cdevents-sdk/src/generated/mod.rs
@@ -3,87 +3,138 @@
 
 use serde::{Serialize, Deserialize, de::Error};
 
+pub mod artifact_deleted_0_1_0;
+pub mod artifact_downloaded_0_1_0;
 pub mod artifact_packaged_0_1_1;
+pub mod artifact_packaged_0_2_0;
 pub mod artifact_published_0_1_1;
+pub mod artifact_published_0_2_0;
 pub mod artifact_signed_0_1_0;
+pub mod artifact_signed_0_2_0;
 pub mod branch_created_0_1_2;
+pub mod branch_created_0_2_0;
 pub mod branch_deleted_0_1_2;
+pub mod branch_deleted_0_2_0;
 pub mod build_finished_0_1_1;
+pub mod build_finished_0_2_0;
 pub mod build_queued_0_1_1;
+pub mod build_queued_0_2_0;
 pub mod build_started_0_1_1;
+pub mod build_started_0_2_0;
 pub mod change_abandoned_0_1_2;
+pub mod change_abandoned_0_2_0;
 pub mod change_created_0_2_0;
 pub mod change_created_0_1_2;
+pub mod change_created_0_3_0;
 pub mod change_merged_0_1_2;
+pub mod change_merged_0_2_0;
 pub mod change_reviewed_0_1_2;
+pub mod change_reviewed_0_2_0;
 pub mod change_updated_0_1_2;
+pub mod change_updated_0_2_0;
 pub mod environment_created_0_1_1;
+pub mod environment_created_0_2_0;
 pub mod environment_deleted_0_1_1;
+pub mod environment_deleted_0_2_0;
 pub mod environment_modified_0_1_1;
+pub mod environment_modified_0_2_0;
 pub mod incident_detected_0_1_0;
+pub mod incident_detected_0_2_0;
 pub mod incident_reported_0_1_0;
+pub mod incident_reported_0_2_0;
 pub mod incident_resolved_0_1_0;
+pub mod incident_resolved_0_2_0;
 pub mod pipelinerun_finished_0_1_1;
+pub mod pipelinerun_finished_0_2_0;
 pub mod pipelinerun_queued_0_1_1;
+pub mod pipelinerun_queued_0_2_0;
 pub mod pipelinerun_started_0_1_1;
+pub mod pipelinerun_started_0_2_0;
 pub mod repository_created_0_1_1;
+pub mod repository_created_0_2_0;
 pub mod repository_deleted_0_1_1;
+pub mod repository_deleted_0_2_0;
 pub mod repository_modified_0_1_1;
+pub mod repository_modified_0_2_0;
 pub mod service_deployed_0_1_1;
+pub mod service_deployed_0_2_0;
 pub mod service_published_0_1_1;
+pub mod service_published_0_2_0;
 pub mod service_removed_0_1_1;
+pub mod service_removed_0_2_0;
 pub mod service_rolledback_0_1_1;
+pub mod service_rolledback_0_2_0;
 pub mod service_upgraded_0_1_1;
+pub mod service_upgraded_0_2_0;
 pub mod taskrun_finished_0_1_1;
+pub mod taskrun_finished_0_2_0;
 pub mod taskrun_started_0_1_1;
+pub mod taskrun_started_0_2_0;
 pub mod testcaserun_finished_0_1_0;
+pub mod testcaserun_finished_0_2_0;
 pub mod testcaserun_queued_0_1_0;
+pub mod testcaserun_queued_0_2_0;
+pub mod testcaserun_skipped_0_1_0;
 pub mod testcaserun_started_0_1_0;
+pub mod testcaserun_started_0_2_0;
 pub mod testoutput_published_0_1_0;
+pub mod testoutput_published_0_2_0;
 pub mod testsuiterun_finished_0_1_0;
+pub mod testsuiterun_finished_0_2_0;
 pub mod testsuiterun_queued_0_1_0;
+pub mod testsuiterun_queued_0_2_0;
 pub mod testsuiterun_started_0_1_0;
+pub mod testsuiterun_started_0_2_0;
+pub mod ticket_closed_0_1_0;
+pub mod ticket_created_0_1_0;
+pub mod ticket_updated_0_1_0;
 
 pub mod latest {
-    pub use super::artifact_packaged_0_1_1 as artifact_packaged;
-    pub use super::artifact_published_0_1_1 as artifact_published;
-    pub use super::artifact_signed_0_1_0 as artifact_signed;
-    pub use super::branch_created_0_1_2 as branch_created;
-    pub use super::branch_deleted_0_1_2 as branch_deleted;
-    pub use super::build_finished_0_1_1 as build_finished;
-    pub use super::build_queued_0_1_1 as build_queued;
-    pub use super::build_started_0_1_1 as build_started;
-    pub use super::change_abandoned_0_1_2 as change_abandoned;
-    pub use super::change_created_0_2_0 as change_created;
-    pub use super::change_merged_0_1_2 as change_merged;
-    pub use super::change_reviewed_0_1_2 as change_reviewed;
-    pub use super::change_updated_0_1_2 as change_updated;
-    pub use super::environment_created_0_1_1 as environment_created;
-    pub use super::environment_deleted_0_1_1 as environment_deleted;
-    pub use super::environment_modified_0_1_1 as environment_modified;
-    pub use super::incident_detected_0_1_0 as incident_detected;
-    pub use super::incident_reported_0_1_0 as incident_reported;
-    pub use super::incident_resolved_0_1_0 as incident_resolved;
-    pub use super::pipelinerun_finished_0_1_1 as pipelinerun_finished;
-    pub use super::pipelinerun_queued_0_1_1 as pipelinerun_queued;
-    pub use super::pipelinerun_started_0_1_1 as pipelinerun_started;
-    pub use super::repository_created_0_1_1 as repository_created;
-    pub use super::repository_deleted_0_1_1 as repository_deleted;
-    pub use super::repository_modified_0_1_1 as repository_modified;
-    pub use super::service_deployed_0_1_1 as service_deployed;
-    pub use super::service_published_0_1_1 as service_published;
-    pub use super::service_removed_0_1_1 as service_removed;
-    pub use super::service_rolledback_0_1_1 as service_rolledback;
-    pub use super::service_upgraded_0_1_1 as service_upgraded;
-    pub use super::taskrun_finished_0_1_1 as taskrun_finished;
-    pub use super::taskrun_started_0_1_1 as taskrun_started;
-    pub use super::testcaserun_finished_0_1_0 as testcaserun_finished;
-    pub use super::testcaserun_queued_0_1_0 as testcaserun_queued;
-    pub use super::testcaserun_started_0_1_0 as testcaserun_started;
-    pub use super::testoutput_published_0_1_0 as testoutput_published;
-    pub use super::testsuiterun_finished_0_1_0 as testsuiterun_finished;
-    pub use super::testsuiterun_queued_0_1_0 as testsuiterun_queued;
-    pub use super::testsuiterun_started_0_1_0 as testsuiterun_started;
+    pub use super::artifact_deleted_0_1_0 as artifact_deleted;
+    pub use super::artifact_downloaded_0_1_0 as artifact_downloaded;
+    pub use super::artifact_packaged_0_2_0 as artifact_packaged;
+    pub use super::artifact_published_0_2_0 as artifact_published;
+    pub use super::artifact_signed_0_2_0 as artifact_signed;
+    pub use super::branch_created_0_2_0 as branch_created;
+    pub use super::branch_deleted_0_2_0 as branch_deleted;
+    pub use super::build_finished_0_2_0 as build_finished;
+    pub use super::build_queued_0_2_0 as build_queued;
+    pub use super::build_started_0_2_0 as build_started;
+    pub use super::change_abandoned_0_2_0 as change_abandoned;
+    pub use super::change_created_0_3_0 as change_created;
+    pub use super::change_merged_0_2_0 as change_merged;
+    pub use super::change_reviewed_0_2_0 as change_reviewed;
+    pub use super::change_updated_0_2_0 as change_updated;
+    pub use super::environment_created_0_2_0 as environment_created;
+    pub use super::environment_deleted_0_2_0 as environment_deleted;
+    pub use super::environment_modified_0_2_0 as environment_modified;
+    pub use super::incident_detected_0_2_0 as incident_detected;
+    pub use super::incident_reported_0_2_0 as incident_reported;
+    pub use super::incident_resolved_0_2_0 as incident_resolved;
+    pub use super::pipelinerun_finished_0_2_0 as pipelinerun_finished;
+    pub use super::pipelinerun_queued_0_2_0 as pipelinerun_queued;
+    pub use super::pipelinerun_started_0_2_0 as pipelinerun_started;
+    pub use super::repository_created_0_2_0 as repository_created;
+    pub use super::repository_deleted_0_2_0 as repository_deleted;
+    pub use super::repository_modified_0_2_0 as repository_modified;
+    pub use super::service_deployed_0_2_0 as service_deployed;
+    pub use super::service_published_0_2_0 as service_published;
+    pub use super::service_removed_0_2_0 as service_removed;
+    pub use super::service_rolledback_0_2_0 as service_rolledback;
+    pub use super::service_upgraded_0_2_0 as service_upgraded;
+    pub use super::taskrun_finished_0_2_0 as taskrun_finished;
+    pub use super::taskrun_started_0_2_0 as taskrun_started;
+    pub use super::testcaserun_finished_0_2_0 as testcaserun_finished;
+    pub use super::testcaserun_queued_0_2_0 as testcaserun_queued;
+    pub use super::testcaserun_skipped_0_1_0 as testcaserun_skipped;
+    pub use super::testcaserun_started_0_2_0 as testcaserun_started;
+    pub use super::testoutput_published_0_2_0 as testoutput_published;
+    pub use super::testsuiterun_finished_0_2_0 as testsuiterun_finished;
+    pub use super::testsuiterun_queued_0_2_0 as testsuiterun_queued;
+    pub use super::testsuiterun_started_0_2_0 as testsuiterun_started;
+    pub use super::ticket_closed_0_1_0 as ticket_closed;
+    pub use super::ticket_created_0_1_0 as ticket_created;
+    pub use super::ticket_updated_0_1_0 as ticket_updated;
 }
 pub mod spec_0_3_0 {
     pub use super::artifact_packaged_0_1_1 as artifact_packaged;
@@ -126,6 +177,53 @@ pub mod spec_0_3_0 {
     pub use super::testsuiterun_queued_0_1_0 as testsuiterun_queued;
     pub use super::testsuiterun_started_0_1_0 as testsuiterun_started;
 }
+pub mod spec_0_4_0 {
+    pub use super::artifact_deleted_0_1_0 as artifact_deleted;
+    pub use super::artifact_downloaded_0_1_0 as artifact_downloaded;
+    pub use super::artifact_packaged_0_2_0 as artifact_packaged;
+    pub use super::artifact_published_0_2_0 as artifact_published;
+    pub use super::artifact_signed_0_2_0 as artifact_signed;
+    pub use super::branch_created_0_2_0 as branch_created;
+    pub use super::branch_deleted_0_2_0 as branch_deleted;
+    pub use super::build_finished_0_2_0 as build_finished;
+    pub use super::build_queued_0_2_0 as build_queued;
+    pub use super::build_started_0_2_0 as build_started;
+    pub use super::change_abandoned_0_2_0 as change_abandoned;
+    pub use super::change_created_0_3_0 as change_created;
+    pub use super::change_merged_0_2_0 as change_merged;
+    pub use super::change_reviewed_0_2_0 as change_reviewed;
+    pub use super::change_updated_0_2_0 as change_updated;
+    pub use super::environment_created_0_2_0 as environment_created;
+    pub use super::environment_deleted_0_2_0 as environment_deleted;
+    pub use super::environment_modified_0_2_0 as environment_modified;
+    pub use super::incident_detected_0_2_0 as incident_detected;
+    pub use super::incident_reported_0_2_0 as incident_reported;
+    pub use super::incident_resolved_0_2_0 as incident_resolved;
+    pub use super::pipelinerun_finished_0_2_0 as pipelinerun_finished;
+    pub use super::pipelinerun_queued_0_2_0 as pipelinerun_queued;
+    pub use super::pipelinerun_started_0_2_0 as pipelinerun_started;
+    pub use super::repository_created_0_2_0 as repository_created;
+    pub use super::repository_deleted_0_2_0 as repository_deleted;
+    pub use super::repository_modified_0_2_0 as repository_modified;
+    pub use super::service_deployed_0_2_0 as service_deployed;
+    pub use super::service_published_0_2_0 as service_published;
+    pub use super::service_removed_0_2_0 as service_removed;
+    pub use super::service_rolledback_0_2_0 as service_rolledback;
+    pub use super::service_upgraded_0_2_0 as service_upgraded;
+    pub use super::taskrun_finished_0_2_0 as taskrun_finished;
+    pub use super::taskrun_started_0_2_0 as taskrun_started;
+    pub use super::testcaserun_finished_0_2_0 as testcaserun_finished;
+    pub use super::testcaserun_queued_0_2_0 as testcaserun_queued;
+    pub use super::testcaserun_skipped_0_1_0 as testcaserun_skipped;
+    pub use super::testcaserun_started_0_2_0 as testcaserun_started;
+    pub use super::testoutput_published_0_2_0 as testoutput_published;
+    pub use super::testsuiterun_finished_0_2_0 as testsuiterun_finished;
+    pub use super::testsuiterun_queued_0_2_0 as testsuiterun_queued;
+    pub use super::testsuiterun_started_0_2_0 as testsuiterun_started;
+    pub use super::ticket_closed_0_1_0 as ticket_closed;
+    pub use super::ticket_created_0_1_0 as ticket_created;
+    pub use super::ticket_updated_0_1_0 as ticket_updated;
+}
 pub mod spec_0_4_0_draft {
     pub use super::artifact_signed_0_1_0 as artifact_signed;
     pub use super::branch_created_0_1_2 as branch_created;
@@ -166,129 +264,263 @@ pub mod spec_0_4_0_draft {
     pub use super::testsuiterun_started_0_1_0 as testsuiterun_started;
 }
 
+pub const ARTIFACT_DELETED_0_1_0: &str = "dev.cdevents.artifact.deleted.0.1.0";
+pub const ARTIFACT_DOWNLOADED_0_1_0: &str = "dev.cdevents.artifact.downloaded.0.1.0";
 pub const ARTIFACT_PACKAGED_0_1_1: &str = "dev.cdevents.artifact.packaged.0.1.1";
+pub const ARTIFACT_PACKAGED_0_2_0: &str = "dev.cdevents.artifact.packaged.0.2.0";
 pub const ARTIFACT_PUBLISHED_0_1_1: &str = "dev.cdevents.artifact.published.0.1.1";
+pub const ARTIFACT_PUBLISHED_0_2_0: &str = "dev.cdevents.artifact.published.0.2.0";
 pub const ARTIFACT_SIGNED_0_1_0: &str = "dev.cdevents.artifact.signed.0.1.0";
+pub const ARTIFACT_SIGNED_0_2_0: &str = "dev.cdevents.artifact.signed.0.2.0";
 pub const BRANCH_CREATED_0_1_2: &str = "dev.cdevents.branch.created.0.1.2";
+pub const BRANCH_CREATED_0_2_0: &str = "dev.cdevents.branch.created.0.2.0";
 pub const BRANCH_DELETED_0_1_2: &str = "dev.cdevents.branch.deleted.0.1.2";
+pub const BRANCH_DELETED_0_2_0: &str = "dev.cdevents.branch.deleted.0.2.0";
 pub const BUILD_FINISHED_0_1_1: &str = "dev.cdevents.build.finished.0.1.1";
+pub const BUILD_FINISHED_0_2_0: &str = "dev.cdevents.build.finished.0.2.0";
 pub const BUILD_QUEUED_0_1_1: &str = "dev.cdevents.build.queued.0.1.1";
+pub const BUILD_QUEUED_0_2_0: &str = "dev.cdevents.build.queued.0.2.0";
 pub const BUILD_STARTED_0_1_1: &str = "dev.cdevents.build.started.0.1.1";
+pub const BUILD_STARTED_0_2_0: &str = "dev.cdevents.build.started.0.2.0";
 pub const CHANGE_ABANDONED_0_1_2: &str = "dev.cdevents.change.abandoned.0.1.2";
+pub const CHANGE_ABANDONED_0_2_0: &str = "dev.cdevents.change.abandoned.0.2.0";
 pub const CHANGE_CREATED_0_2_0: &str = "dev.cdevents.change.created.0.2.0";
 pub const CHANGE_CREATED_0_1_2: &str = "dev.cdevents.change.created.0.1.2";
+pub const CHANGE_CREATED_0_3_0: &str = "dev.cdevents.change.created.0.3.0";
 pub const CHANGE_MERGED_0_1_2: &str = "dev.cdevents.change.merged.0.1.2";
+pub const CHANGE_MERGED_0_2_0: &str = "dev.cdevents.change.merged.0.2.0";
 pub const CHANGE_REVIEWED_0_1_2: &str = "dev.cdevents.change.reviewed.0.1.2";
+pub const CHANGE_REVIEWED_0_2_0: &str = "dev.cdevents.change.reviewed.0.2.0";
 pub const CHANGE_UPDATED_0_1_2: &str = "dev.cdevents.change.updated.0.1.2";
+pub const CHANGE_UPDATED_0_2_0: &str = "dev.cdevents.change.updated.0.2.0";
 pub const ENVIRONMENT_CREATED_0_1_1: &str = "dev.cdevents.environment.created.0.1.1";
+pub const ENVIRONMENT_CREATED_0_2_0: &str = "dev.cdevents.environment.created.0.2.0";
 pub const ENVIRONMENT_DELETED_0_1_1: &str = "dev.cdevents.environment.deleted.0.1.1";
+pub const ENVIRONMENT_DELETED_0_2_0: &str = "dev.cdevents.environment.deleted.0.2.0";
 pub const ENVIRONMENT_MODIFIED_0_1_1: &str = "dev.cdevents.environment.modified.0.1.1";
+pub const ENVIRONMENT_MODIFIED_0_2_0: &str = "dev.cdevents.environment.modified.0.2.0";
 pub const INCIDENT_DETECTED_0_1_0: &str = "dev.cdevents.incident.detected.0.1.0";
+pub const INCIDENT_DETECTED_0_2_0: &str = "dev.cdevents.incident.detected.0.2.0";
 pub const INCIDENT_REPORTED_0_1_0: &str = "dev.cdevents.incident.reported.0.1.0";
+pub const INCIDENT_REPORTED_0_2_0: &str = "dev.cdevents.incident.reported.0.2.0";
 pub const INCIDENT_RESOLVED_0_1_0: &str = "dev.cdevents.incident.resolved.0.1.0";
+pub const INCIDENT_RESOLVED_0_2_0: &str = "dev.cdevents.incident.resolved.0.2.0";
 pub const PIPELINERUN_FINISHED_0_1_1: &str = "dev.cdevents.pipelinerun.finished.0.1.1";
+pub const PIPELINERUN_FINISHED_0_2_0: &str = "dev.cdevents.pipelinerun.finished.0.2.0";
 pub const PIPELINERUN_QUEUED_0_1_1: &str = "dev.cdevents.pipelinerun.queued.0.1.1";
+pub const PIPELINERUN_QUEUED_0_2_0: &str = "dev.cdevents.pipelinerun.queued.0.2.0";
 pub const PIPELINERUN_STARTED_0_1_1: &str = "dev.cdevents.pipelinerun.started.0.1.1";
+pub const PIPELINERUN_STARTED_0_2_0: &str = "dev.cdevents.pipelinerun.started.0.2.0";
 pub const REPOSITORY_CREATED_0_1_1: &str = "dev.cdevents.repository.created.0.1.1";
+pub const REPOSITORY_CREATED_0_2_0: &str = "dev.cdevents.repository.created.0.2.0";
 pub const REPOSITORY_DELETED_0_1_1: &str = "dev.cdevents.repository.deleted.0.1.1";
+pub const REPOSITORY_DELETED_0_2_0: &str = "dev.cdevents.repository.deleted.0.2.0";
 pub const REPOSITORY_MODIFIED_0_1_1: &str = "dev.cdevents.repository.modified.0.1.1";
+pub const REPOSITORY_MODIFIED_0_2_0: &str = "dev.cdevents.repository.modified.0.2.0";
 pub const SERVICE_DEPLOYED_0_1_1: &str = "dev.cdevents.service.deployed.0.1.1";
+pub const SERVICE_DEPLOYED_0_2_0: &str = "dev.cdevents.service.deployed.0.2.0";
 pub const SERVICE_PUBLISHED_0_1_1: &str = "dev.cdevents.service.published.0.1.1";
+pub const SERVICE_PUBLISHED_0_2_0: &str = "dev.cdevents.service.published.0.2.0";
 pub const SERVICE_REMOVED_0_1_1: &str = "dev.cdevents.service.removed.0.1.1";
+pub const SERVICE_REMOVED_0_2_0: &str = "dev.cdevents.service.removed.0.2.0";
 pub const SERVICE_ROLLEDBACK_0_1_1: &str = "dev.cdevents.service.rolledback.0.1.1";
+pub const SERVICE_ROLLEDBACK_0_2_0: &str = "dev.cdevents.service.rolledback.0.2.0";
 pub const SERVICE_UPGRADED_0_1_1: &str = "dev.cdevents.service.upgraded.0.1.1";
+pub const SERVICE_UPGRADED_0_2_0: &str = "dev.cdevents.service.upgraded.0.2.0";
 pub const TASKRUN_FINISHED_0_1_1: &str = "dev.cdevents.taskrun.finished.0.1.1";
+pub const TASKRUN_FINISHED_0_2_0: &str = "dev.cdevents.taskrun.finished.0.2.0";
 pub const TASKRUN_STARTED_0_1_1: &str = "dev.cdevents.taskrun.started.0.1.1";
+pub const TASKRUN_STARTED_0_2_0: &str = "dev.cdevents.taskrun.started.0.2.0";
 pub const TESTCASERUN_FINISHED_0_1_0: &str = "dev.cdevents.testcaserun.finished.0.1.0";
+pub const TESTCASERUN_FINISHED_0_2_0: &str = "dev.cdevents.testcaserun.finished.0.2.0";
 pub const TESTCASERUN_QUEUED_0_1_0: &str = "dev.cdevents.testcaserun.queued.0.1.0";
+pub const TESTCASERUN_QUEUED_0_2_0: &str = "dev.cdevents.testcaserun.queued.0.2.0";
+pub const TESTCASERUN_SKIPPED_0_1_0: &str = "dev.cdevents.testcaserun.skipped.0.1.0";
 pub const TESTCASERUN_STARTED_0_1_0: &str = "dev.cdevents.testcaserun.started.0.1.0";
+pub const TESTCASERUN_STARTED_0_2_0: &str = "dev.cdevents.testcaserun.started.0.2.0";
 pub const TESTOUTPUT_PUBLISHED_0_1_0: &str = "dev.cdevents.testoutput.published.0.1.0";
+pub const TESTOUTPUT_PUBLISHED_0_2_0: &str = "dev.cdevents.testoutput.published.0.2.0";
 pub const TESTSUITERUN_FINISHED_0_1_0: &str = "dev.cdevents.testsuiterun.finished.0.1.0";
+pub const TESTSUITERUN_FINISHED_0_2_0: &str = "dev.cdevents.testsuiterun.finished.0.2.0";
 pub const TESTSUITERUN_QUEUED_0_1_0: &str = "dev.cdevents.testsuiterun.queued.0.1.0";
+pub const TESTSUITERUN_QUEUED_0_2_0: &str = "dev.cdevents.testsuiterun.queued.0.2.0";
 pub const TESTSUITERUN_STARTED_0_1_0: &str = "dev.cdevents.testsuiterun.started.0.1.0";
+pub const TESTSUITERUN_STARTED_0_2_0: &str = "dev.cdevents.testsuiterun.started.0.2.0";
+pub const TICKET_CLOSED_0_1_0: &str = "dev.cdevents.ticket.closed.0.1.0";
+pub const TICKET_CREATED_0_1_0: &str = "dev.cdevents.ticket.created.0.1.0";
+pub const TICKET_UPDATED_0_1_0: &str = "dev.cdevents.ticket.updated.0.1.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)] // TODO how to use content of context.type as discriminator ?
 pub enum Content {
+    ArtifactDeleted010(artifact_deleted_0_1_0::Content),
+    ArtifactDownloaded010(artifact_downloaded_0_1_0::Content),
     ArtifactPackaged011(artifact_packaged_0_1_1::Content),
+    ArtifactPackaged020(artifact_packaged_0_2_0::Content),
     ArtifactPublished011(artifact_published_0_1_1::Content),
+    ArtifactPublished020(artifact_published_0_2_0::Content),
     ArtifactSigned010(artifact_signed_0_1_0::Content),
+    ArtifactSigned020(artifact_signed_0_2_0::Content),
     BranchCreated012(branch_created_0_1_2::Content),
+    BranchCreated020(branch_created_0_2_0::Content),
     BranchDeleted012(branch_deleted_0_1_2::Content),
+    BranchDeleted020(branch_deleted_0_2_0::Content),
     BuildFinished011(build_finished_0_1_1::Content),
+    BuildFinished020(build_finished_0_2_0::Content),
     BuildQueued011(build_queued_0_1_1::Content),
+    BuildQueued020(build_queued_0_2_0::Content),
     BuildStarted011(build_started_0_1_1::Content),
+    BuildStarted020(build_started_0_2_0::Content),
     ChangeAbandoned012(change_abandoned_0_1_2::Content),
+    ChangeAbandoned020(change_abandoned_0_2_0::Content),
     ChangeCreated020(change_created_0_2_0::Content),
     ChangeCreated012(change_created_0_1_2::Content),
+    ChangeCreated030(change_created_0_3_0::Content),
     ChangeMerged012(change_merged_0_1_2::Content),
+    ChangeMerged020(change_merged_0_2_0::Content),
     ChangeReviewed012(change_reviewed_0_1_2::Content),
+    ChangeReviewed020(change_reviewed_0_2_0::Content),
     ChangeUpdated012(change_updated_0_1_2::Content),
+    ChangeUpdated020(change_updated_0_2_0::Content),
     EnvironmentCreated011(environment_created_0_1_1::Content),
+    EnvironmentCreated020(environment_created_0_2_0::Content),
     EnvironmentDeleted011(environment_deleted_0_1_1::Content),
+    EnvironmentDeleted020(environment_deleted_0_2_0::Content),
     EnvironmentModified011(environment_modified_0_1_1::Content),
+    EnvironmentModified020(environment_modified_0_2_0::Content),
     IncidentDetected010(incident_detected_0_1_0::Content),
+    IncidentDetected020(incident_detected_0_2_0::Content),
     IncidentReported010(incident_reported_0_1_0::Content),
+    IncidentReported020(incident_reported_0_2_0::Content),
     IncidentResolved010(incident_resolved_0_1_0::Content),
+    IncidentResolved020(incident_resolved_0_2_0::Content),
     PipelinerunFinished011(pipelinerun_finished_0_1_1::Content),
+    PipelinerunFinished020(pipelinerun_finished_0_2_0::Content),
     PipelinerunQueued011(pipelinerun_queued_0_1_1::Content),
+    PipelinerunQueued020(pipelinerun_queued_0_2_0::Content),
     PipelinerunStarted011(pipelinerun_started_0_1_1::Content),
+    PipelinerunStarted020(pipelinerun_started_0_2_0::Content),
     RepositoryCreated011(repository_created_0_1_1::Content),
+    RepositoryCreated020(repository_created_0_2_0::Content),
     RepositoryDeleted011(repository_deleted_0_1_1::Content),
+    RepositoryDeleted020(repository_deleted_0_2_0::Content),
     RepositoryModified011(repository_modified_0_1_1::Content),
+    RepositoryModified020(repository_modified_0_2_0::Content),
     ServiceDeployed011(service_deployed_0_1_1::Content),
+    ServiceDeployed020(service_deployed_0_2_0::Content),
     ServicePublished011(service_published_0_1_1::Content),
+    ServicePublished020(service_published_0_2_0::Content),
     ServiceRemoved011(service_removed_0_1_1::Content),
+    ServiceRemoved020(service_removed_0_2_0::Content),
     ServiceRolledback011(service_rolledback_0_1_1::Content),
+    ServiceRolledback020(service_rolledback_0_2_0::Content),
     ServiceUpgraded011(service_upgraded_0_1_1::Content),
+    ServiceUpgraded020(service_upgraded_0_2_0::Content),
     TaskrunFinished011(taskrun_finished_0_1_1::Content),
+    TaskrunFinished020(taskrun_finished_0_2_0::Content),
     TaskrunStarted011(taskrun_started_0_1_1::Content),
+    TaskrunStarted020(taskrun_started_0_2_0::Content),
     TestcaserunFinished010(testcaserun_finished_0_1_0::Content),
+    TestcaserunFinished020(testcaserun_finished_0_2_0::Content),
     TestcaserunQueued010(testcaserun_queued_0_1_0::Content),
+    TestcaserunQueued020(testcaserun_queued_0_2_0::Content),
+    TestcaserunSkipped010(testcaserun_skipped_0_1_0::Content),
     TestcaserunStarted010(testcaserun_started_0_1_0::Content),
+    TestcaserunStarted020(testcaserun_started_0_2_0::Content),
     TestoutputPublished010(testoutput_published_0_1_0::Content),
+    TestoutputPublished020(testoutput_published_0_2_0::Content),
     TestsuiterunFinished010(testsuiterun_finished_0_1_0::Content),
+    TestsuiterunFinished020(testsuiterun_finished_0_2_0::Content),
     TestsuiterunQueued010(testsuiterun_queued_0_1_0::Content),
+    TestsuiterunQueued020(testsuiterun_queued_0_2_0::Content),
     TestsuiterunStarted010(testsuiterun_started_0_1_0::Content),
+    TestsuiterunStarted020(testsuiterun_started_0_2_0::Content),
+    TicketClosed010(ticket_closed_0_1_0::Content),
+    TicketCreated010(ticket_created_0_1_0::Content),
+    TicketUpdated010(ticket_updated_0_1_0::Content),
 }
 
 impl Content {
     pub fn from_json(ty: &str, json: serde_json::Value) -> Result<Self, serde_json::Error>{
         match ty {
+            ARTIFACT_DELETED_0_1_0 => {
+                let variant: artifact_deleted_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            ARTIFACT_DOWNLOADED_0_1_0 => {
+                let variant: artifact_downloaded_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             ARTIFACT_PACKAGED_0_1_1 => {
                 let variant: artifact_packaged_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            ARTIFACT_PACKAGED_0_2_0 => {
+                let variant: artifact_packaged_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             ARTIFACT_PUBLISHED_0_1_1 => {
                 let variant: artifact_published_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            ARTIFACT_PUBLISHED_0_2_0 => {
+                let variant: artifact_published_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             ARTIFACT_SIGNED_0_1_0 => {
                 let variant: artifact_signed_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            ARTIFACT_SIGNED_0_2_0 => {
+                let variant: artifact_signed_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             BRANCH_CREATED_0_1_2 => {
                 let variant: branch_created_0_1_2::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            BRANCH_CREATED_0_2_0 => {
+                let variant: branch_created_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             BRANCH_DELETED_0_1_2 => {
                 let variant: branch_deleted_0_1_2::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            BRANCH_DELETED_0_2_0 => {
+                let variant: branch_deleted_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             BUILD_FINISHED_0_1_1 => {
                 let variant: build_finished_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            BUILD_FINISHED_0_2_0 => {
+                let variant: build_finished_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             BUILD_QUEUED_0_1_1 => {
                 let variant: build_queued_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            BUILD_QUEUED_0_2_0 => {
+                let variant: build_queued_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             BUILD_STARTED_0_1_1 => {
                 let variant: build_started_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            BUILD_STARTED_0_2_0 => {
+                let variant: build_started_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             CHANGE_ABANDONED_0_1_2 => {
                 let variant: change_abandoned_0_1_2::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            CHANGE_ABANDONED_0_2_0 => {
+                let variant: change_abandoned_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             CHANGE_CREATED_0_2_0 => {
@@ -299,120 +531,256 @@ impl Content {
                 let variant: change_created_0_1_2::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            CHANGE_CREATED_0_3_0 => {
+                let variant: change_created_0_3_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             CHANGE_MERGED_0_1_2 => {
                 let variant: change_merged_0_1_2::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            CHANGE_MERGED_0_2_0 => {
+                let variant: change_merged_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             CHANGE_REVIEWED_0_1_2 => {
                 let variant: change_reviewed_0_1_2::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            CHANGE_REVIEWED_0_2_0 => {
+                let variant: change_reviewed_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             CHANGE_UPDATED_0_1_2 => {
                 let variant: change_updated_0_1_2::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            CHANGE_UPDATED_0_2_0 => {
+                let variant: change_updated_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             ENVIRONMENT_CREATED_0_1_1 => {
                 let variant: environment_created_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            ENVIRONMENT_CREATED_0_2_0 => {
+                let variant: environment_created_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             ENVIRONMENT_DELETED_0_1_1 => {
                 let variant: environment_deleted_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            ENVIRONMENT_DELETED_0_2_0 => {
+                let variant: environment_deleted_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             ENVIRONMENT_MODIFIED_0_1_1 => {
                 let variant: environment_modified_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            ENVIRONMENT_MODIFIED_0_2_0 => {
+                let variant: environment_modified_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             INCIDENT_DETECTED_0_1_0 => {
                 let variant: incident_detected_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            INCIDENT_DETECTED_0_2_0 => {
+                let variant: incident_detected_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             INCIDENT_REPORTED_0_1_0 => {
                 let variant: incident_reported_0_1_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            INCIDENT_REPORTED_0_2_0 => {
+                let variant: incident_reported_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             INCIDENT_RESOLVED_0_1_0 => {
                 let variant: incident_resolved_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            INCIDENT_RESOLVED_0_2_0 => {
+                let variant: incident_resolved_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             PIPELINERUN_FINISHED_0_1_1 => {
                 let variant: pipelinerun_finished_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            PIPELINERUN_FINISHED_0_2_0 => {
+                let variant: pipelinerun_finished_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             PIPELINERUN_QUEUED_0_1_1 => {
                 let variant: pipelinerun_queued_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            PIPELINERUN_QUEUED_0_2_0 => {
+                let variant: pipelinerun_queued_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             PIPELINERUN_STARTED_0_1_1 => {
                 let variant: pipelinerun_started_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            PIPELINERUN_STARTED_0_2_0 => {
+                let variant: pipelinerun_started_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             REPOSITORY_CREATED_0_1_1 => {
                 let variant: repository_created_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            REPOSITORY_CREATED_0_2_0 => {
+                let variant: repository_created_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             REPOSITORY_DELETED_0_1_1 => {
                 let variant: repository_deleted_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            REPOSITORY_DELETED_0_2_0 => {
+                let variant: repository_deleted_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             REPOSITORY_MODIFIED_0_1_1 => {
                 let variant: repository_modified_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            REPOSITORY_MODIFIED_0_2_0 => {
+                let variant: repository_modified_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             SERVICE_DEPLOYED_0_1_1 => {
                 let variant: service_deployed_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            SERVICE_DEPLOYED_0_2_0 => {
+                let variant: service_deployed_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             SERVICE_PUBLISHED_0_1_1 => {
                 let variant: service_published_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            SERVICE_PUBLISHED_0_2_0 => {
+                let variant: service_published_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             SERVICE_REMOVED_0_1_1 => {
                 let variant: service_removed_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            SERVICE_REMOVED_0_2_0 => {
+                let variant: service_removed_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             SERVICE_ROLLEDBACK_0_1_1 => {
                 let variant: service_rolledback_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            SERVICE_ROLLEDBACK_0_2_0 => {
+                let variant: service_rolledback_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             SERVICE_UPGRADED_0_1_1 => {
                 let variant: service_upgraded_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            SERVICE_UPGRADED_0_2_0 => {
+                let variant: service_upgraded_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             TASKRUN_FINISHED_0_1_1 => {
                 let variant: taskrun_finished_0_1_1::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TASKRUN_FINISHED_0_2_0 => {
+                let variant: taskrun_finished_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             TASKRUN_STARTED_0_1_1 => {
                 let variant: taskrun_started_0_1_1::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            TASKRUN_STARTED_0_2_0 => {
+                let variant: taskrun_started_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             TESTCASERUN_FINISHED_0_1_0 => {
                 let variant: testcaserun_finished_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TESTCASERUN_FINISHED_0_2_0 => {
+                let variant: testcaserun_finished_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             TESTCASERUN_QUEUED_0_1_0 => {
                 let variant: testcaserun_queued_0_1_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            TESTCASERUN_QUEUED_0_2_0 => {
+                let variant: testcaserun_queued_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TESTCASERUN_SKIPPED_0_1_0 => {
+                let variant: testcaserun_skipped_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             TESTCASERUN_STARTED_0_1_0 => {
                 let variant: testcaserun_started_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TESTCASERUN_STARTED_0_2_0 => {
+                let variant: testcaserun_started_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             TESTOUTPUT_PUBLISHED_0_1_0 => {
                 let variant: testoutput_published_0_1_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            TESTOUTPUT_PUBLISHED_0_2_0 => {
+                let variant: testoutput_published_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             TESTSUITERUN_FINISHED_0_1_0 => {
                 let variant: testsuiterun_finished_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TESTSUITERUN_FINISHED_0_2_0 => {
+                let variant: testsuiterun_finished_0_2_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             TESTSUITERUN_QUEUED_0_1_0 => {
                 let variant: testsuiterun_queued_0_1_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
+            TESTSUITERUN_QUEUED_0_2_0 => {
+                let variant: testsuiterun_queued_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
             TESTSUITERUN_STARTED_0_1_0 => {
                 let variant: testsuiterun_started_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TESTSUITERUN_STARTED_0_2_0 => {
+                let variant: testsuiterun_started_0_2_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TICKET_CLOSED_0_1_0 => {
+                let variant: ticket_closed_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TICKET_CREATED_0_1_0 => {
+                let variant: ticket_created_0_1_0::Content = serde_json::from_value(json)?;
+                Ok(variant.into())
+            },
+            TICKET_UPDATED_0_1_0 => {
+                let variant: ticket_updated_0_1_0::Content = serde_json::from_value(json)?;
                 Ok(variant.into())
             },
             variant => Err(serde_json::Error::custom(format_args!(
@@ -424,136 +792,271 @@ impl Content {
 
     pub fn ty(&self) -> &'static str {
         match self {
+            Self::ArtifactDeleted010(_) => ARTIFACT_DELETED_0_1_0,
+            Self::ArtifactDownloaded010(_) => ARTIFACT_DOWNLOADED_0_1_0,
             Self::ArtifactPackaged011(_) => ARTIFACT_PACKAGED_0_1_1,
+            Self::ArtifactPackaged020(_) => ARTIFACT_PACKAGED_0_2_0,
             Self::ArtifactPublished011(_) => ARTIFACT_PUBLISHED_0_1_1,
+            Self::ArtifactPublished020(_) => ARTIFACT_PUBLISHED_0_2_0,
             Self::ArtifactSigned010(_) => ARTIFACT_SIGNED_0_1_0,
+            Self::ArtifactSigned020(_) => ARTIFACT_SIGNED_0_2_0,
             Self::BranchCreated012(_) => BRANCH_CREATED_0_1_2,
+            Self::BranchCreated020(_) => BRANCH_CREATED_0_2_0,
             Self::BranchDeleted012(_) => BRANCH_DELETED_0_1_2,
+            Self::BranchDeleted020(_) => BRANCH_DELETED_0_2_0,
             Self::BuildFinished011(_) => BUILD_FINISHED_0_1_1,
+            Self::BuildFinished020(_) => BUILD_FINISHED_0_2_0,
             Self::BuildQueued011(_) => BUILD_QUEUED_0_1_1,
+            Self::BuildQueued020(_) => BUILD_QUEUED_0_2_0,
             Self::BuildStarted011(_) => BUILD_STARTED_0_1_1,
+            Self::BuildStarted020(_) => BUILD_STARTED_0_2_0,
             Self::ChangeAbandoned012(_) => CHANGE_ABANDONED_0_1_2,
+            Self::ChangeAbandoned020(_) => CHANGE_ABANDONED_0_2_0,
             Self::ChangeCreated020(_) => CHANGE_CREATED_0_2_0,
             Self::ChangeCreated012(_) => CHANGE_CREATED_0_1_2,
+            Self::ChangeCreated030(_) => CHANGE_CREATED_0_3_0,
             Self::ChangeMerged012(_) => CHANGE_MERGED_0_1_2,
+            Self::ChangeMerged020(_) => CHANGE_MERGED_0_2_0,
             Self::ChangeReviewed012(_) => CHANGE_REVIEWED_0_1_2,
+            Self::ChangeReviewed020(_) => CHANGE_REVIEWED_0_2_0,
             Self::ChangeUpdated012(_) => CHANGE_UPDATED_0_1_2,
+            Self::ChangeUpdated020(_) => CHANGE_UPDATED_0_2_0,
             Self::EnvironmentCreated011(_) => ENVIRONMENT_CREATED_0_1_1,
+            Self::EnvironmentCreated020(_) => ENVIRONMENT_CREATED_0_2_0,
             Self::EnvironmentDeleted011(_) => ENVIRONMENT_DELETED_0_1_1,
+            Self::EnvironmentDeleted020(_) => ENVIRONMENT_DELETED_0_2_0,
             Self::EnvironmentModified011(_) => ENVIRONMENT_MODIFIED_0_1_1,
+            Self::EnvironmentModified020(_) => ENVIRONMENT_MODIFIED_0_2_0,
             Self::IncidentDetected010(_) => INCIDENT_DETECTED_0_1_0,
+            Self::IncidentDetected020(_) => INCIDENT_DETECTED_0_2_0,
             Self::IncidentReported010(_) => INCIDENT_REPORTED_0_1_0,
+            Self::IncidentReported020(_) => INCIDENT_REPORTED_0_2_0,
             Self::IncidentResolved010(_) => INCIDENT_RESOLVED_0_1_0,
+            Self::IncidentResolved020(_) => INCIDENT_RESOLVED_0_2_0,
             Self::PipelinerunFinished011(_) => PIPELINERUN_FINISHED_0_1_1,
+            Self::PipelinerunFinished020(_) => PIPELINERUN_FINISHED_0_2_0,
             Self::PipelinerunQueued011(_) => PIPELINERUN_QUEUED_0_1_1,
+            Self::PipelinerunQueued020(_) => PIPELINERUN_QUEUED_0_2_0,
             Self::PipelinerunStarted011(_) => PIPELINERUN_STARTED_0_1_1,
+            Self::PipelinerunStarted020(_) => PIPELINERUN_STARTED_0_2_0,
             Self::RepositoryCreated011(_) => REPOSITORY_CREATED_0_1_1,
+            Self::RepositoryCreated020(_) => REPOSITORY_CREATED_0_2_0,
             Self::RepositoryDeleted011(_) => REPOSITORY_DELETED_0_1_1,
+            Self::RepositoryDeleted020(_) => REPOSITORY_DELETED_0_2_0,
             Self::RepositoryModified011(_) => REPOSITORY_MODIFIED_0_1_1,
+            Self::RepositoryModified020(_) => REPOSITORY_MODIFIED_0_2_0,
             Self::ServiceDeployed011(_) => SERVICE_DEPLOYED_0_1_1,
+            Self::ServiceDeployed020(_) => SERVICE_DEPLOYED_0_2_0,
             Self::ServicePublished011(_) => SERVICE_PUBLISHED_0_1_1,
+            Self::ServicePublished020(_) => SERVICE_PUBLISHED_0_2_0,
             Self::ServiceRemoved011(_) => SERVICE_REMOVED_0_1_1,
+            Self::ServiceRemoved020(_) => SERVICE_REMOVED_0_2_0,
             Self::ServiceRolledback011(_) => SERVICE_ROLLEDBACK_0_1_1,
+            Self::ServiceRolledback020(_) => SERVICE_ROLLEDBACK_0_2_0,
             Self::ServiceUpgraded011(_) => SERVICE_UPGRADED_0_1_1,
+            Self::ServiceUpgraded020(_) => SERVICE_UPGRADED_0_2_0,
             Self::TaskrunFinished011(_) => TASKRUN_FINISHED_0_1_1,
+            Self::TaskrunFinished020(_) => TASKRUN_FINISHED_0_2_0,
             Self::TaskrunStarted011(_) => TASKRUN_STARTED_0_1_1,
+            Self::TaskrunStarted020(_) => TASKRUN_STARTED_0_2_0,
             Self::TestcaserunFinished010(_) => TESTCASERUN_FINISHED_0_1_0,
+            Self::TestcaserunFinished020(_) => TESTCASERUN_FINISHED_0_2_0,
             Self::TestcaserunQueued010(_) => TESTCASERUN_QUEUED_0_1_0,
+            Self::TestcaserunQueued020(_) => TESTCASERUN_QUEUED_0_2_0,
+            Self::TestcaserunSkipped010(_) => TESTCASERUN_SKIPPED_0_1_0,
             Self::TestcaserunStarted010(_) => TESTCASERUN_STARTED_0_1_0,
+            Self::TestcaserunStarted020(_) => TESTCASERUN_STARTED_0_2_0,
             Self::TestoutputPublished010(_) => TESTOUTPUT_PUBLISHED_0_1_0,
+            Self::TestoutputPublished020(_) => TESTOUTPUT_PUBLISHED_0_2_0,
             Self::TestsuiterunFinished010(_) => TESTSUITERUN_FINISHED_0_1_0,
+            Self::TestsuiterunFinished020(_) => TESTSUITERUN_FINISHED_0_2_0,
             Self::TestsuiterunQueued010(_) => TESTSUITERUN_QUEUED_0_1_0,
+            Self::TestsuiterunQueued020(_) => TESTSUITERUN_QUEUED_0_2_0,
             Self::TestsuiterunStarted010(_) => TESTSUITERUN_STARTED_0_1_0,
+            Self::TestsuiterunStarted020(_) => TESTSUITERUN_STARTED_0_2_0,
+            Self::TicketClosed010(_) => TICKET_CLOSED_0_1_0,
+            Self::TicketCreated010(_) => TICKET_CREATED_0_1_0,
+            Self::TicketUpdated010(_) => TICKET_UPDATED_0_1_0,
         }
     }
 
     pub fn subject(&self) -> &'static str {
         match self {
+            Self::ArtifactDeleted010(_) => "artifact",
+            Self::ArtifactDownloaded010(_) => "artifact",
             Self::ArtifactPackaged011(_) => "artifact",
+            Self::ArtifactPackaged020(_) => "artifact",
             Self::ArtifactPublished011(_) => "artifact",
+            Self::ArtifactPublished020(_) => "artifact",
             Self::ArtifactSigned010(_) => "artifact",
+            Self::ArtifactSigned020(_) => "artifact",
             Self::BranchCreated012(_) => "branch",
+            Self::BranchCreated020(_) => "branch",
             Self::BranchDeleted012(_) => "branch",
+            Self::BranchDeleted020(_) => "branch",
             Self::BuildFinished011(_) => "build",
+            Self::BuildFinished020(_) => "build",
             Self::BuildQueued011(_) => "build",
+            Self::BuildQueued020(_) => "build",
             Self::BuildStarted011(_) => "build",
+            Self::BuildStarted020(_) => "build",
             Self::ChangeAbandoned012(_) => "change",
+            Self::ChangeAbandoned020(_) => "change",
             Self::ChangeCreated020(_) => "change",
             Self::ChangeCreated012(_) => "change",
+            Self::ChangeCreated030(_) => "change",
             Self::ChangeMerged012(_) => "change",
+            Self::ChangeMerged020(_) => "change",
             Self::ChangeReviewed012(_) => "change",
+            Self::ChangeReviewed020(_) => "change",
             Self::ChangeUpdated012(_) => "change",
+            Self::ChangeUpdated020(_) => "change",
             Self::EnvironmentCreated011(_) => "environment",
+            Self::EnvironmentCreated020(_) => "environment",
             Self::EnvironmentDeleted011(_) => "environment",
+            Self::EnvironmentDeleted020(_) => "environment",
             Self::EnvironmentModified011(_) => "environment",
+            Self::EnvironmentModified020(_) => "environment",
             Self::IncidentDetected010(_) => "incident",
+            Self::IncidentDetected020(_) => "incident",
             Self::IncidentReported010(_) => "incident",
+            Self::IncidentReported020(_) => "incident",
             Self::IncidentResolved010(_) => "incident",
+            Self::IncidentResolved020(_) => "incident",
             Self::PipelinerunFinished011(_) => "pipelineRun",
+            Self::PipelinerunFinished020(_) => "pipelineRun",
             Self::PipelinerunQueued011(_) => "pipelineRun",
+            Self::PipelinerunQueued020(_) => "pipelineRun",
             Self::PipelinerunStarted011(_) => "pipelineRun",
+            Self::PipelinerunStarted020(_) => "pipelineRun",
             Self::RepositoryCreated011(_) => "repository",
+            Self::RepositoryCreated020(_) => "repository",
             Self::RepositoryDeleted011(_) => "repository",
+            Self::RepositoryDeleted020(_) => "repository",
             Self::RepositoryModified011(_) => "repository",
+            Self::RepositoryModified020(_) => "repository",
             Self::ServiceDeployed011(_) => "service",
+            Self::ServiceDeployed020(_) => "service",
             Self::ServicePublished011(_) => "service",
+            Self::ServicePublished020(_) => "service",
             Self::ServiceRemoved011(_) => "service",
+            Self::ServiceRemoved020(_) => "service",
             Self::ServiceRolledback011(_) => "service",
+            Self::ServiceRolledback020(_) => "service",
             Self::ServiceUpgraded011(_) => "service",
+            Self::ServiceUpgraded020(_) => "service",
             Self::TaskrunFinished011(_) => "taskRun",
+            Self::TaskrunFinished020(_) => "taskRun",
             Self::TaskrunStarted011(_) => "taskRun",
+            Self::TaskrunStarted020(_) => "taskRun",
             Self::TestcaserunFinished010(_) => "testCaseRun",
+            Self::TestcaserunFinished020(_) => "testCaseRun",
             Self::TestcaserunQueued010(_) => "testCaseRun",
+            Self::TestcaserunQueued020(_) => "testCaseRun",
+            Self::TestcaserunSkipped010(_) => "testCaseRun",
             Self::TestcaserunStarted010(_) => "testCaseRun",
+            Self::TestcaserunStarted020(_) => "testCaseRun",
             Self::TestoutputPublished010(_) => "testOutput",
+            Self::TestoutputPublished020(_) => "testOutput",
             Self::TestsuiterunFinished010(_) => "testSuiteRun",
+            Self::TestsuiterunFinished020(_) => "testSuiteRun",
             Self::TestsuiterunQueued010(_) => "testSuiteRun",
+            Self::TestsuiterunQueued020(_) => "testSuiteRun",
             Self::TestsuiterunStarted010(_) => "testSuiteRun",
+            Self::TestsuiterunStarted020(_) => "testSuiteRun",
+            Self::TicketClosed010(_) => "ticket",
+            Self::TicketCreated010(_) => "ticket",
+            Self::TicketUpdated010(_) => "ticket",
         }
     }
 
     pub fn predicate(&self) -> &'static str {
         match self {
+            Self::ArtifactDeleted010(_) => "deleted",
+            Self::ArtifactDownloaded010(_) => "downloaded",
             Self::ArtifactPackaged011(_) => "packaged",
+            Self::ArtifactPackaged020(_) => "packaged",
             Self::ArtifactPublished011(_) => "published",
+            Self::ArtifactPublished020(_) => "published",
             Self::ArtifactSigned010(_) => "signed",
+            Self::ArtifactSigned020(_) => "signed",
             Self::BranchCreated012(_) => "created",
+            Self::BranchCreated020(_) => "created",
             Self::BranchDeleted012(_) => "deleted",
+            Self::BranchDeleted020(_) => "deleted",
             Self::BuildFinished011(_) => "finished",
+            Self::BuildFinished020(_) => "finished",
             Self::BuildQueued011(_) => "queued",
+            Self::BuildQueued020(_) => "queued",
             Self::BuildStarted011(_) => "started",
+            Self::BuildStarted020(_) => "started",
             Self::ChangeAbandoned012(_) => "abandoned",
+            Self::ChangeAbandoned020(_) => "abandoned",
             Self::ChangeCreated020(_) => "created",
             Self::ChangeCreated012(_) => "created",
+            Self::ChangeCreated030(_) => "created",
             Self::ChangeMerged012(_) => "merged",
+            Self::ChangeMerged020(_) => "merged",
             Self::ChangeReviewed012(_) => "reviewed",
+            Self::ChangeReviewed020(_) => "reviewed",
             Self::ChangeUpdated012(_) => "updated",
+            Self::ChangeUpdated020(_) => "updated",
             Self::EnvironmentCreated011(_) => "created",
+            Self::EnvironmentCreated020(_) => "created",
             Self::EnvironmentDeleted011(_) => "deleted",
+            Self::EnvironmentDeleted020(_) => "deleted",
             Self::EnvironmentModified011(_) => "modified",
+            Self::EnvironmentModified020(_) => "modified",
             Self::IncidentDetected010(_) => "detected",
+            Self::IncidentDetected020(_) => "detected",
             Self::IncidentReported010(_) => "reported",
+            Self::IncidentReported020(_) => "reported",
             Self::IncidentResolved010(_) => "resolved",
+            Self::IncidentResolved020(_) => "resolved",
             Self::PipelinerunFinished011(_) => "finished",
+            Self::PipelinerunFinished020(_) => "finished",
             Self::PipelinerunQueued011(_) => "queued",
+            Self::PipelinerunQueued020(_) => "queued",
             Self::PipelinerunStarted011(_) => "started",
+            Self::PipelinerunStarted020(_) => "started",
             Self::RepositoryCreated011(_) => "created",
+            Self::RepositoryCreated020(_) => "created",
             Self::RepositoryDeleted011(_) => "deleted",
+            Self::RepositoryDeleted020(_) => "deleted",
             Self::RepositoryModified011(_) => "modified",
+            Self::RepositoryModified020(_) => "modified",
             Self::ServiceDeployed011(_) => "deployed",
+            Self::ServiceDeployed020(_) => "deployed",
             Self::ServicePublished011(_) => "published",
+            Self::ServicePublished020(_) => "published",
             Self::ServiceRemoved011(_) => "removed",
+            Self::ServiceRemoved020(_) => "removed",
             Self::ServiceRolledback011(_) => "rolledback",
+            Self::ServiceRolledback020(_) => "rolledback",
             Self::ServiceUpgraded011(_) => "upgraded",
+            Self::ServiceUpgraded020(_) => "upgraded",
             Self::TaskrunFinished011(_) => "finished",
+            Self::TaskrunFinished020(_) => "finished",
             Self::TaskrunStarted011(_) => "started",
+            Self::TaskrunStarted020(_) => "started",
             Self::TestcaserunFinished010(_) => "finished",
+            Self::TestcaserunFinished020(_) => "finished",
             Self::TestcaserunQueued010(_) => "queued",
+            Self::TestcaserunQueued020(_) => "queued",
+            Self::TestcaserunSkipped010(_) => "skipped",
             Self::TestcaserunStarted010(_) => "started",
+            Self::TestcaserunStarted020(_) => "started",
             Self::TestoutputPublished010(_) => "published",
+            Self::TestoutputPublished020(_) => "published",
             Self::TestsuiterunFinished010(_) => "finished",
+            Self::TestsuiterunFinished020(_) => "finished",
             Self::TestsuiterunQueued010(_) => "queued",
+            Self::TestsuiterunQueued020(_) => "queued",
             Self::TestsuiterunStarted010(_) => "started",
+            Self::TestsuiterunStarted020(_) => "started",
+            Self::TicketClosed010(_) => "closed",
+            Self::TicketCreated010(_) => "created",
+            Self::TicketUpdated010(_) => "updated",
         }
     }
 }
@@ -562,53 +1065,113 @@ impl Content {
 pub fn extract_subject_predicate(ty: &str) -> Option<(&str, &str)>{
     // let mut split = ty.split('.');
     match ty {
+        ARTIFACT_DELETED_0_1_0 => Some(("artifact", "deleted")),
+        ARTIFACT_DOWNLOADED_0_1_0 => Some(("artifact", "downloaded")),
         ARTIFACT_PACKAGED_0_1_1 => Some(("artifact", "packaged")),
+        ARTIFACT_PACKAGED_0_2_0 => Some(("artifact", "packaged")),
         ARTIFACT_PUBLISHED_0_1_1 => Some(("artifact", "published")),
+        ARTIFACT_PUBLISHED_0_2_0 => Some(("artifact", "published")),
         ARTIFACT_SIGNED_0_1_0 => Some(("artifact", "signed")),
+        ARTIFACT_SIGNED_0_2_0 => Some(("artifact", "signed")),
         BRANCH_CREATED_0_1_2 => Some(("branch", "created")),
+        BRANCH_CREATED_0_2_0 => Some(("branch", "created")),
         BRANCH_DELETED_0_1_2 => Some(("branch", "deleted")),
+        BRANCH_DELETED_0_2_0 => Some(("branch", "deleted")),
         BUILD_FINISHED_0_1_1 => Some(("build", "finished")),
+        BUILD_FINISHED_0_2_0 => Some(("build", "finished")),
         BUILD_QUEUED_0_1_1 => Some(("build", "queued")),
+        BUILD_QUEUED_0_2_0 => Some(("build", "queued")),
         BUILD_STARTED_0_1_1 => Some(("build", "started")),
+        BUILD_STARTED_0_2_0 => Some(("build", "started")),
         CHANGE_ABANDONED_0_1_2 => Some(("change", "abandoned")),
+        CHANGE_ABANDONED_0_2_0 => Some(("change", "abandoned")),
         CHANGE_CREATED_0_2_0 => Some(("change", "created")),
         CHANGE_CREATED_0_1_2 => Some(("change", "created")),
+        CHANGE_CREATED_0_3_0 => Some(("change", "created")),
         CHANGE_MERGED_0_1_2 => Some(("change", "merged")),
+        CHANGE_MERGED_0_2_0 => Some(("change", "merged")),
         CHANGE_REVIEWED_0_1_2 => Some(("change", "reviewed")),
+        CHANGE_REVIEWED_0_2_0 => Some(("change", "reviewed")),
         CHANGE_UPDATED_0_1_2 => Some(("change", "updated")),
+        CHANGE_UPDATED_0_2_0 => Some(("change", "updated")),
         ENVIRONMENT_CREATED_0_1_1 => Some(("environment", "created")),
+        ENVIRONMENT_CREATED_0_2_0 => Some(("environment", "created")),
         ENVIRONMENT_DELETED_0_1_1 => Some(("environment", "deleted")),
+        ENVIRONMENT_DELETED_0_2_0 => Some(("environment", "deleted")),
         ENVIRONMENT_MODIFIED_0_1_1 => Some(("environment", "modified")),
+        ENVIRONMENT_MODIFIED_0_2_0 => Some(("environment", "modified")),
         INCIDENT_DETECTED_0_1_0 => Some(("incident", "detected")),
+        INCIDENT_DETECTED_0_2_0 => Some(("incident", "detected")),
         INCIDENT_REPORTED_0_1_0 => Some(("incident", "reported")),
+        INCIDENT_REPORTED_0_2_0 => Some(("incident", "reported")),
         INCIDENT_RESOLVED_0_1_0 => Some(("incident", "resolved")),
+        INCIDENT_RESOLVED_0_2_0 => Some(("incident", "resolved")),
         PIPELINERUN_FINISHED_0_1_1 => Some(("pipelineRun", "finished")),
+        PIPELINERUN_FINISHED_0_2_0 => Some(("pipelineRun", "finished")),
         PIPELINERUN_QUEUED_0_1_1 => Some(("pipelineRun", "queued")),
+        PIPELINERUN_QUEUED_0_2_0 => Some(("pipelineRun", "queued")),
         PIPELINERUN_STARTED_0_1_1 => Some(("pipelineRun", "started")),
+        PIPELINERUN_STARTED_0_2_0 => Some(("pipelineRun", "started")),
         REPOSITORY_CREATED_0_1_1 => Some(("repository", "created")),
+        REPOSITORY_CREATED_0_2_0 => Some(("repository", "created")),
         REPOSITORY_DELETED_0_1_1 => Some(("repository", "deleted")),
+        REPOSITORY_DELETED_0_2_0 => Some(("repository", "deleted")),
         REPOSITORY_MODIFIED_0_1_1 => Some(("repository", "modified")),
+        REPOSITORY_MODIFIED_0_2_0 => Some(("repository", "modified")),
         SERVICE_DEPLOYED_0_1_1 => Some(("service", "deployed")),
+        SERVICE_DEPLOYED_0_2_0 => Some(("service", "deployed")),
         SERVICE_PUBLISHED_0_1_1 => Some(("service", "published")),
+        SERVICE_PUBLISHED_0_2_0 => Some(("service", "published")),
         SERVICE_REMOVED_0_1_1 => Some(("service", "removed")),
+        SERVICE_REMOVED_0_2_0 => Some(("service", "removed")),
         SERVICE_ROLLEDBACK_0_1_1 => Some(("service", "rolledback")),
+        SERVICE_ROLLEDBACK_0_2_0 => Some(("service", "rolledback")),
         SERVICE_UPGRADED_0_1_1 => Some(("service", "upgraded")),
+        SERVICE_UPGRADED_0_2_0 => Some(("service", "upgraded")),
         TASKRUN_FINISHED_0_1_1 => Some(("taskRun", "finished")),
+        TASKRUN_FINISHED_0_2_0 => Some(("taskRun", "finished")),
         TASKRUN_STARTED_0_1_1 => Some(("taskRun", "started")),
+        TASKRUN_STARTED_0_2_0 => Some(("taskRun", "started")),
         TESTCASERUN_FINISHED_0_1_0 => Some(("testCaseRun", "finished")),
+        TESTCASERUN_FINISHED_0_2_0 => Some(("testCaseRun", "finished")),
         TESTCASERUN_QUEUED_0_1_0 => Some(("testCaseRun", "queued")),
+        TESTCASERUN_QUEUED_0_2_0 => Some(("testCaseRun", "queued")),
+        TESTCASERUN_SKIPPED_0_1_0 => Some(("testCaseRun", "skipped")),
         TESTCASERUN_STARTED_0_1_0 => Some(("testCaseRun", "started")),
+        TESTCASERUN_STARTED_0_2_0 => Some(("testCaseRun", "started")),
         TESTOUTPUT_PUBLISHED_0_1_0 => Some(("testOutput", "published")),
+        TESTOUTPUT_PUBLISHED_0_2_0 => Some(("testOutput", "published")),
         TESTSUITERUN_FINISHED_0_1_0 => Some(("testSuiteRun", "finished")),
+        TESTSUITERUN_FINISHED_0_2_0 => Some(("testSuiteRun", "finished")),
         TESTSUITERUN_QUEUED_0_1_0 => Some(("testSuiteRun", "queued")),
+        TESTSUITERUN_QUEUED_0_2_0 => Some(("testSuiteRun", "queued")),
         TESTSUITERUN_STARTED_0_1_0 => Some(("testSuiteRun", "started")),
+        TESTSUITERUN_STARTED_0_2_0 => Some(("testSuiteRun", "started")),
+        TICKET_CLOSED_0_1_0 => Some(("ticket", "closed")),
+        TICKET_CREATED_0_1_0 => Some(("ticket", "created")),
+        TICKET_UPDATED_0_1_0 => Some(("ticket", "updated")),
         _ => None,
     }
 }
 
+impl From<artifact_deleted_0_1_0::Content> for Content {
+    fn from(value: artifact_deleted_0_1_0::Content) -> Self {
+        Self::ArtifactDeleted010(value)
+    }
+}
+impl From<artifact_downloaded_0_1_0::Content> for Content {
+    fn from(value: artifact_downloaded_0_1_0::Content) -> Self {
+        Self::ArtifactDownloaded010(value)
+    }
+}
 impl From<artifact_packaged_0_1_1::Content> for Content {
     fn from(value: artifact_packaged_0_1_1::Content) -> Self {
         Self::ArtifactPackaged011(value)
+    }
+}
+impl From<artifact_packaged_0_2_0::Content> for Content {
+    fn from(value: artifact_packaged_0_2_0::Content) -> Self {
+        Self::ArtifactPackaged020(value)
     }
 }
 impl From<artifact_published_0_1_1::Content> for Content {
@@ -616,9 +1179,19 @@ impl From<artifact_published_0_1_1::Content> for Content {
         Self::ArtifactPublished011(value)
     }
 }
+impl From<artifact_published_0_2_0::Content> for Content {
+    fn from(value: artifact_published_0_2_0::Content) -> Self {
+        Self::ArtifactPublished020(value)
+    }
+}
 impl From<artifact_signed_0_1_0::Content> for Content {
     fn from(value: artifact_signed_0_1_0::Content) -> Self {
         Self::ArtifactSigned010(value)
+    }
+}
+impl From<artifact_signed_0_2_0::Content> for Content {
+    fn from(value: artifact_signed_0_2_0::Content) -> Self {
+        Self::ArtifactSigned020(value)
     }
 }
 impl From<branch_created_0_1_2::Content> for Content {
@@ -626,9 +1199,19 @@ impl From<branch_created_0_1_2::Content> for Content {
         Self::BranchCreated012(value)
     }
 }
+impl From<branch_created_0_2_0::Content> for Content {
+    fn from(value: branch_created_0_2_0::Content) -> Self {
+        Self::BranchCreated020(value)
+    }
+}
 impl From<branch_deleted_0_1_2::Content> for Content {
     fn from(value: branch_deleted_0_1_2::Content) -> Self {
         Self::BranchDeleted012(value)
+    }
+}
+impl From<branch_deleted_0_2_0::Content> for Content {
+    fn from(value: branch_deleted_0_2_0::Content) -> Self {
+        Self::BranchDeleted020(value)
     }
 }
 impl From<build_finished_0_1_1::Content> for Content {
@@ -636,9 +1219,19 @@ impl From<build_finished_0_1_1::Content> for Content {
         Self::BuildFinished011(value)
     }
 }
+impl From<build_finished_0_2_0::Content> for Content {
+    fn from(value: build_finished_0_2_0::Content) -> Self {
+        Self::BuildFinished020(value)
+    }
+}
 impl From<build_queued_0_1_1::Content> for Content {
     fn from(value: build_queued_0_1_1::Content) -> Self {
         Self::BuildQueued011(value)
+    }
+}
+impl From<build_queued_0_2_0::Content> for Content {
+    fn from(value: build_queued_0_2_0::Content) -> Self {
+        Self::BuildQueued020(value)
     }
 }
 impl From<build_started_0_1_1::Content> for Content {
@@ -646,9 +1239,19 @@ impl From<build_started_0_1_1::Content> for Content {
         Self::BuildStarted011(value)
     }
 }
+impl From<build_started_0_2_0::Content> for Content {
+    fn from(value: build_started_0_2_0::Content) -> Self {
+        Self::BuildStarted020(value)
+    }
+}
 impl From<change_abandoned_0_1_2::Content> for Content {
     fn from(value: change_abandoned_0_1_2::Content) -> Self {
         Self::ChangeAbandoned012(value)
+    }
+}
+impl From<change_abandoned_0_2_0::Content> for Content {
+    fn from(value: change_abandoned_0_2_0::Content) -> Self {
+        Self::ChangeAbandoned020(value)
     }
 }
 impl From<change_created_0_2_0::Content> for Content {
@@ -661,9 +1264,19 @@ impl From<change_created_0_1_2::Content> for Content {
         Self::ChangeCreated012(value)
     }
 }
+impl From<change_created_0_3_0::Content> for Content {
+    fn from(value: change_created_0_3_0::Content) -> Self {
+        Self::ChangeCreated030(value)
+    }
+}
 impl From<change_merged_0_1_2::Content> for Content {
     fn from(value: change_merged_0_1_2::Content) -> Self {
         Self::ChangeMerged012(value)
+    }
+}
+impl From<change_merged_0_2_0::Content> for Content {
+    fn from(value: change_merged_0_2_0::Content) -> Self {
+        Self::ChangeMerged020(value)
     }
 }
 impl From<change_reviewed_0_1_2::Content> for Content {
@@ -671,9 +1284,19 @@ impl From<change_reviewed_0_1_2::Content> for Content {
         Self::ChangeReviewed012(value)
     }
 }
+impl From<change_reviewed_0_2_0::Content> for Content {
+    fn from(value: change_reviewed_0_2_0::Content) -> Self {
+        Self::ChangeReviewed020(value)
+    }
+}
 impl From<change_updated_0_1_2::Content> for Content {
     fn from(value: change_updated_0_1_2::Content) -> Self {
         Self::ChangeUpdated012(value)
+    }
+}
+impl From<change_updated_0_2_0::Content> for Content {
+    fn from(value: change_updated_0_2_0::Content) -> Self {
+        Self::ChangeUpdated020(value)
     }
 }
 impl From<environment_created_0_1_1::Content> for Content {
@@ -681,9 +1304,19 @@ impl From<environment_created_0_1_1::Content> for Content {
         Self::EnvironmentCreated011(value)
     }
 }
+impl From<environment_created_0_2_0::Content> for Content {
+    fn from(value: environment_created_0_2_0::Content) -> Self {
+        Self::EnvironmentCreated020(value)
+    }
+}
 impl From<environment_deleted_0_1_1::Content> for Content {
     fn from(value: environment_deleted_0_1_1::Content) -> Self {
         Self::EnvironmentDeleted011(value)
+    }
+}
+impl From<environment_deleted_0_2_0::Content> for Content {
+    fn from(value: environment_deleted_0_2_0::Content) -> Self {
+        Self::EnvironmentDeleted020(value)
     }
 }
 impl From<environment_modified_0_1_1::Content> for Content {
@@ -691,9 +1324,19 @@ impl From<environment_modified_0_1_1::Content> for Content {
         Self::EnvironmentModified011(value)
     }
 }
+impl From<environment_modified_0_2_0::Content> for Content {
+    fn from(value: environment_modified_0_2_0::Content) -> Self {
+        Self::EnvironmentModified020(value)
+    }
+}
 impl From<incident_detected_0_1_0::Content> for Content {
     fn from(value: incident_detected_0_1_0::Content) -> Self {
         Self::IncidentDetected010(value)
+    }
+}
+impl From<incident_detected_0_2_0::Content> for Content {
+    fn from(value: incident_detected_0_2_0::Content) -> Self {
+        Self::IncidentDetected020(value)
     }
 }
 impl From<incident_reported_0_1_0::Content> for Content {
@@ -701,9 +1344,19 @@ impl From<incident_reported_0_1_0::Content> for Content {
         Self::IncidentReported010(value)
     }
 }
+impl From<incident_reported_0_2_0::Content> for Content {
+    fn from(value: incident_reported_0_2_0::Content) -> Self {
+        Self::IncidentReported020(value)
+    }
+}
 impl From<incident_resolved_0_1_0::Content> for Content {
     fn from(value: incident_resolved_0_1_0::Content) -> Self {
         Self::IncidentResolved010(value)
+    }
+}
+impl From<incident_resolved_0_2_0::Content> for Content {
+    fn from(value: incident_resolved_0_2_0::Content) -> Self {
+        Self::IncidentResolved020(value)
     }
 }
 impl From<pipelinerun_finished_0_1_1::Content> for Content {
@@ -711,9 +1364,19 @@ impl From<pipelinerun_finished_0_1_1::Content> for Content {
         Self::PipelinerunFinished011(value)
     }
 }
+impl From<pipelinerun_finished_0_2_0::Content> for Content {
+    fn from(value: pipelinerun_finished_0_2_0::Content) -> Self {
+        Self::PipelinerunFinished020(value)
+    }
+}
 impl From<pipelinerun_queued_0_1_1::Content> for Content {
     fn from(value: pipelinerun_queued_0_1_1::Content) -> Self {
         Self::PipelinerunQueued011(value)
+    }
+}
+impl From<pipelinerun_queued_0_2_0::Content> for Content {
+    fn from(value: pipelinerun_queued_0_2_0::Content) -> Self {
+        Self::PipelinerunQueued020(value)
     }
 }
 impl From<pipelinerun_started_0_1_1::Content> for Content {
@@ -721,9 +1384,19 @@ impl From<pipelinerun_started_0_1_1::Content> for Content {
         Self::PipelinerunStarted011(value)
     }
 }
+impl From<pipelinerun_started_0_2_0::Content> for Content {
+    fn from(value: pipelinerun_started_0_2_0::Content) -> Self {
+        Self::PipelinerunStarted020(value)
+    }
+}
 impl From<repository_created_0_1_1::Content> for Content {
     fn from(value: repository_created_0_1_1::Content) -> Self {
         Self::RepositoryCreated011(value)
+    }
+}
+impl From<repository_created_0_2_0::Content> for Content {
+    fn from(value: repository_created_0_2_0::Content) -> Self {
+        Self::RepositoryCreated020(value)
     }
 }
 impl From<repository_deleted_0_1_1::Content> for Content {
@@ -731,9 +1404,19 @@ impl From<repository_deleted_0_1_1::Content> for Content {
         Self::RepositoryDeleted011(value)
     }
 }
+impl From<repository_deleted_0_2_0::Content> for Content {
+    fn from(value: repository_deleted_0_2_0::Content) -> Self {
+        Self::RepositoryDeleted020(value)
+    }
+}
 impl From<repository_modified_0_1_1::Content> for Content {
     fn from(value: repository_modified_0_1_1::Content) -> Self {
         Self::RepositoryModified011(value)
+    }
+}
+impl From<repository_modified_0_2_0::Content> for Content {
+    fn from(value: repository_modified_0_2_0::Content) -> Self {
+        Self::RepositoryModified020(value)
     }
 }
 impl From<service_deployed_0_1_1::Content> for Content {
@@ -741,9 +1424,19 @@ impl From<service_deployed_0_1_1::Content> for Content {
         Self::ServiceDeployed011(value)
     }
 }
+impl From<service_deployed_0_2_0::Content> for Content {
+    fn from(value: service_deployed_0_2_0::Content) -> Self {
+        Self::ServiceDeployed020(value)
+    }
+}
 impl From<service_published_0_1_1::Content> for Content {
     fn from(value: service_published_0_1_1::Content) -> Self {
         Self::ServicePublished011(value)
+    }
+}
+impl From<service_published_0_2_0::Content> for Content {
+    fn from(value: service_published_0_2_0::Content) -> Self {
+        Self::ServicePublished020(value)
     }
 }
 impl From<service_removed_0_1_1::Content> for Content {
@@ -751,9 +1444,19 @@ impl From<service_removed_0_1_1::Content> for Content {
         Self::ServiceRemoved011(value)
     }
 }
+impl From<service_removed_0_2_0::Content> for Content {
+    fn from(value: service_removed_0_2_0::Content) -> Self {
+        Self::ServiceRemoved020(value)
+    }
+}
 impl From<service_rolledback_0_1_1::Content> for Content {
     fn from(value: service_rolledback_0_1_1::Content) -> Self {
         Self::ServiceRolledback011(value)
+    }
+}
+impl From<service_rolledback_0_2_0::Content> for Content {
+    fn from(value: service_rolledback_0_2_0::Content) -> Self {
+        Self::ServiceRolledback020(value)
     }
 }
 impl From<service_upgraded_0_1_1::Content> for Content {
@@ -761,9 +1464,19 @@ impl From<service_upgraded_0_1_1::Content> for Content {
         Self::ServiceUpgraded011(value)
     }
 }
+impl From<service_upgraded_0_2_0::Content> for Content {
+    fn from(value: service_upgraded_0_2_0::Content) -> Self {
+        Self::ServiceUpgraded020(value)
+    }
+}
 impl From<taskrun_finished_0_1_1::Content> for Content {
     fn from(value: taskrun_finished_0_1_1::Content) -> Self {
         Self::TaskrunFinished011(value)
+    }
+}
+impl From<taskrun_finished_0_2_0::Content> for Content {
+    fn from(value: taskrun_finished_0_2_0::Content) -> Self {
+        Self::TaskrunFinished020(value)
     }
 }
 impl From<taskrun_started_0_1_1::Content> for Content {
@@ -771,9 +1484,19 @@ impl From<taskrun_started_0_1_1::Content> for Content {
         Self::TaskrunStarted011(value)
     }
 }
+impl From<taskrun_started_0_2_0::Content> for Content {
+    fn from(value: taskrun_started_0_2_0::Content) -> Self {
+        Self::TaskrunStarted020(value)
+    }
+}
 impl From<testcaserun_finished_0_1_0::Content> for Content {
     fn from(value: testcaserun_finished_0_1_0::Content) -> Self {
         Self::TestcaserunFinished010(value)
+    }
+}
+impl From<testcaserun_finished_0_2_0::Content> for Content {
+    fn from(value: testcaserun_finished_0_2_0::Content) -> Self {
+        Self::TestcaserunFinished020(value)
     }
 }
 impl From<testcaserun_queued_0_1_0::Content> for Content {
@@ -781,9 +1504,24 @@ impl From<testcaserun_queued_0_1_0::Content> for Content {
         Self::TestcaserunQueued010(value)
     }
 }
+impl From<testcaserun_queued_0_2_0::Content> for Content {
+    fn from(value: testcaserun_queued_0_2_0::Content) -> Self {
+        Self::TestcaserunQueued020(value)
+    }
+}
+impl From<testcaserun_skipped_0_1_0::Content> for Content {
+    fn from(value: testcaserun_skipped_0_1_0::Content) -> Self {
+        Self::TestcaserunSkipped010(value)
+    }
+}
 impl From<testcaserun_started_0_1_0::Content> for Content {
     fn from(value: testcaserun_started_0_1_0::Content) -> Self {
         Self::TestcaserunStarted010(value)
+    }
+}
+impl From<testcaserun_started_0_2_0::Content> for Content {
+    fn from(value: testcaserun_started_0_2_0::Content) -> Self {
+        Self::TestcaserunStarted020(value)
     }
 }
 impl From<testoutput_published_0_1_0::Content> for Content {
@@ -791,9 +1529,19 @@ impl From<testoutput_published_0_1_0::Content> for Content {
         Self::TestoutputPublished010(value)
     }
 }
+impl From<testoutput_published_0_2_0::Content> for Content {
+    fn from(value: testoutput_published_0_2_0::Content) -> Self {
+        Self::TestoutputPublished020(value)
+    }
+}
 impl From<testsuiterun_finished_0_1_0::Content> for Content {
     fn from(value: testsuiterun_finished_0_1_0::Content) -> Self {
         Self::TestsuiterunFinished010(value)
+    }
+}
+impl From<testsuiterun_finished_0_2_0::Content> for Content {
+    fn from(value: testsuiterun_finished_0_2_0::Content) -> Self {
+        Self::TestsuiterunFinished020(value)
     }
 }
 impl From<testsuiterun_queued_0_1_0::Content> for Content {
@@ -801,9 +1549,34 @@ impl From<testsuiterun_queued_0_1_0::Content> for Content {
         Self::TestsuiterunQueued010(value)
     }
 }
+impl From<testsuiterun_queued_0_2_0::Content> for Content {
+    fn from(value: testsuiterun_queued_0_2_0::Content) -> Self {
+        Self::TestsuiterunQueued020(value)
+    }
+}
 impl From<testsuiterun_started_0_1_0::Content> for Content {
     fn from(value: testsuiterun_started_0_1_0::Content) -> Self {
         Self::TestsuiterunStarted010(value)
+    }
+}
+impl From<testsuiterun_started_0_2_0::Content> for Content {
+    fn from(value: testsuiterun_started_0_2_0::Content) -> Self {
+        Self::TestsuiterunStarted020(value)
+    }
+}
+impl From<ticket_closed_0_1_0::Content> for Content {
+    fn from(value: ticket_closed_0_1_0::Content) -> Self {
+        Self::TicketClosed010(value)
+    }
+}
+impl From<ticket_created_0_1_0::Content> for Content {
+    fn from(value: ticket_created_0_1_0::Content) -> Self {
+        Self::TicketCreated010(value)
+    }
+}
+impl From<ticket_updated_0_1_0::Content> for Content {
+    fn from(value: ticket_updated_0_1_0::Content) -> Self {
+        Self::TicketUpdated010(value)
     }
 }
 
@@ -815,46 +1588,91 @@ impl<> proptest::arbitrary::Arbitrary for Content {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         use proptest::prelude::*;
         prop_oneof![
+            any::<artifact_deleted_0_1_0::Content>().prop_map(Content::from),
+            any::<artifact_downloaded_0_1_0::Content>().prop_map(Content::from),
             any::<artifact_packaged_0_1_1::Content>().prop_map(Content::from),
+            any::<artifact_packaged_0_2_0::Content>().prop_map(Content::from),
             any::<artifact_published_0_1_1::Content>().prop_map(Content::from),
+            any::<artifact_published_0_2_0::Content>().prop_map(Content::from),
             any::<artifact_signed_0_1_0::Content>().prop_map(Content::from),
+            any::<artifact_signed_0_2_0::Content>().prop_map(Content::from),
             any::<branch_created_0_1_2::Content>().prop_map(Content::from),
+            any::<branch_created_0_2_0::Content>().prop_map(Content::from),
             any::<branch_deleted_0_1_2::Content>().prop_map(Content::from),
+            any::<branch_deleted_0_2_0::Content>().prop_map(Content::from),
             any::<build_finished_0_1_1::Content>().prop_map(Content::from),
+            any::<build_finished_0_2_0::Content>().prop_map(Content::from),
             any::<build_queued_0_1_1::Content>().prop_map(Content::from),
+            any::<build_queued_0_2_0::Content>().prop_map(Content::from),
             any::<build_started_0_1_1::Content>().prop_map(Content::from),
+            any::<build_started_0_2_0::Content>().prop_map(Content::from),
             any::<change_abandoned_0_1_2::Content>().prop_map(Content::from),
+            any::<change_abandoned_0_2_0::Content>().prop_map(Content::from),
             any::<change_created_0_2_0::Content>().prop_map(Content::from),
             any::<change_created_0_1_2::Content>().prop_map(Content::from),
+            any::<change_created_0_3_0::Content>().prop_map(Content::from),
             any::<change_merged_0_1_2::Content>().prop_map(Content::from),
+            any::<change_merged_0_2_0::Content>().prop_map(Content::from),
             any::<change_reviewed_0_1_2::Content>().prop_map(Content::from),
+            any::<change_reviewed_0_2_0::Content>().prop_map(Content::from),
             any::<change_updated_0_1_2::Content>().prop_map(Content::from),
+            any::<change_updated_0_2_0::Content>().prop_map(Content::from),
             any::<environment_created_0_1_1::Content>().prop_map(Content::from),
+            any::<environment_created_0_2_0::Content>().prop_map(Content::from),
             any::<environment_deleted_0_1_1::Content>().prop_map(Content::from),
+            any::<environment_deleted_0_2_0::Content>().prop_map(Content::from),
             any::<environment_modified_0_1_1::Content>().prop_map(Content::from),
+            any::<environment_modified_0_2_0::Content>().prop_map(Content::from),
             any::<incident_detected_0_1_0::Content>().prop_map(Content::from),
+            any::<incident_detected_0_2_0::Content>().prop_map(Content::from),
             any::<incident_reported_0_1_0::Content>().prop_map(Content::from),
+            any::<incident_reported_0_2_0::Content>().prop_map(Content::from),
             any::<incident_resolved_0_1_0::Content>().prop_map(Content::from),
+            any::<incident_resolved_0_2_0::Content>().prop_map(Content::from),
             any::<pipelinerun_finished_0_1_1::Content>().prop_map(Content::from),
+            any::<pipelinerun_finished_0_2_0::Content>().prop_map(Content::from),
             any::<pipelinerun_queued_0_1_1::Content>().prop_map(Content::from),
+            any::<pipelinerun_queued_0_2_0::Content>().prop_map(Content::from),
             any::<pipelinerun_started_0_1_1::Content>().prop_map(Content::from),
+            any::<pipelinerun_started_0_2_0::Content>().prop_map(Content::from),
             any::<repository_created_0_1_1::Content>().prop_map(Content::from),
+            any::<repository_created_0_2_0::Content>().prop_map(Content::from),
             any::<repository_deleted_0_1_1::Content>().prop_map(Content::from),
+            any::<repository_deleted_0_2_0::Content>().prop_map(Content::from),
             any::<repository_modified_0_1_1::Content>().prop_map(Content::from),
+            any::<repository_modified_0_2_0::Content>().prop_map(Content::from),
             any::<service_deployed_0_1_1::Content>().prop_map(Content::from),
+            any::<service_deployed_0_2_0::Content>().prop_map(Content::from),
             any::<service_published_0_1_1::Content>().prop_map(Content::from),
+            any::<service_published_0_2_0::Content>().prop_map(Content::from),
             any::<service_removed_0_1_1::Content>().prop_map(Content::from),
+            any::<service_removed_0_2_0::Content>().prop_map(Content::from),
             any::<service_rolledback_0_1_1::Content>().prop_map(Content::from),
+            any::<service_rolledback_0_2_0::Content>().prop_map(Content::from),
             any::<service_upgraded_0_1_1::Content>().prop_map(Content::from),
+            any::<service_upgraded_0_2_0::Content>().prop_map(Content::from),
             any::<taskrun_finished_0_1_1::Content>().prop_map(Content::from),
+            any::<taskrun_finished_0_2_0::Content>().prop_map(Content::from),
             any::<taskrun_started_0_1_1::Content>().prop_map(Content::from),
+            any::<taskrun_started_0_2_0::Content>().prop_map(Content::from),
             any::<testcaserun_finished_0_1_0::Content>().prop_map(Content::from),
+            any::<testcaserun_finished_0_2_0::Content>().prop_map(Content::from),
             any::<testcaserun_queued_0_1_0::Content>().prop_map(Content::from),
+            any::<testcaserun_queued_0_2_0::Content>().prop_map(Content::from),
+            any::<testcaserun_skipped_0_1_0::Content>().prop_map(Content::from),
             any::<testcaserun_started_0_1_0::Content>().prop_map(Content::from),
+            any::<testcaserun_started_0_2_0::Content>().prop_map(Content::from),
             any::<testoutput_published_0_1_0::Content>().prop_map(Content::from),
+            any::<testoutput_published_0_2_0::Content>().prop_map(Content::from),
             any::<testsuiterun_finished_0_1_0::Content>().prop_map(Content::from),
+            any::<testsuiterun_finished_0_2_0::Content>().prop_map(Content::from),
             any::<testsuiterun_queued_0_1_0::Content>().prop_map(Content::from),
+            any::<testsuiterun_queued_0_2_0::Content>().prop_map(Content::from),
             any::<testsuiterun_started_0_1_0::Content>().prop_map(Content::from),
+            any::<testsuiterun_started_0_2_0::Content>().prop_map(Content::from),
+            any::<ticket_closed_0_1_0::Content>().prop_map(Content::from),
+            any::<ticket_created_0_1_0::Content>().prop_map(Content::from),
+            any::<ticket_updated_0_1_0::Content>().prop_map(Content::from),
         ].boxed()
     }
 }
@@ -866,85 +1684,175 @@ impl<> proptest::arbitrary::Arbitrary for Content {
 //     #[test]
 //     fn test_true() {
 //         
+//         assert_eq!(extract_subject_predicate(ARTIFACT_DELETED_0_1_0), Some(("artifact","deleted")));
+//         
+//         assert_eq!(extract_subject_predicate(ARTIFACT_DOWNLOADED_0_1_0), Some(("artifact","downloaded")));
+//         
 //         assert_eq!(extract_subject_predicate(ARTIFACT_PACKAGED_0_1_1), Some(("artifact","packaged")));
+//         
+//         assert_eq!(extract_subject_predicate(ARTIFACT_PACKAGED_0_2_0), Some(("artifact","packaged")));
 //         
 //         assert_eq!(extract_subject_predicate(ARTIFACT_PUBLISHED_0_1_1), Some(("artifact","published")));
 //         
+//         assert_eq!(extract_subject_predicate(ARTIFACT_PUBLISHED_0_2_0), Some(("artifact","published")));
+//         
 //         assert_eq!(extract_subject_predicate(ARTIFACT_SIGNED_0_1_0), Some(("artifact","signed")));
+//         
+//         assert_eq!(extract_subject_predicate(ARTIFACT_SIGNED_0_2_0), Some(("artifact","signed")));
 //         
 //         assert_eq!(extract_subject_predicate(BRANCH_CREATED_0_1_2), Some(("branch","created")));
 //         
+//         assert_eq!(extract_subject_predicate(BRANCH_CREATED_0_2_0), Some(("branch","created")));
+//         
 //         assert_eq!(extract_subject_predicate(BRANCH_DELETED_0_1_2), Some(("branch","deleted")));
+//         
+//         assert_eq!(extract_subject_predicate(BRANCH_DELETED_0_2_0), Some(("branch","deleted")));
 //         
 //         assert_eq!(extract_subject_predicate(BUILD_FINISHED_0_1_1), Some(("build","finished")));
 //         
+//         assert_eq!(extract_subject_predicate(BUILD_FINISHED_0_2_0), Some(("build","finished")));
+//         
 //         assert_eq!(extract_subject_predicate(BUILD_QUEUED_0_1_1), Some(("build","queued")));
+//         
+//         assert_eq!(extract_subject_predicate(BUILD_QUEUED_0_2_0), Some(("build","queued")));
 //         
 //         assert_eq!(extract_subject_predicate(BUILD_STARTED_0_1_1), Some(("build","started")));
 //         
+//         assert_eq!(extract_subject_predicate(BUILD_STARTED_0_2_0), Some(("build","started")));
+//         
 //         assert_eq!(extract_subject_predicate(CHANGE_ABANDONED_0_1_2), Some(("change","abandoned")));
+//         
+//         assert_eq!(extract_subject_predicate(CHANGE_ABANDONED_0_2_0), Some(("change","abandoned")));
 //         
 //         assert_eq!(extract_subject_predicate(CHANGE_CREATED_0_2_0), Some(("change","created")));
 //         
 //         assert_eq!(extract_subject_predicate(CHANGE_CREATED_0_1_2), Some(("change","created")));
 //         
+//         assert_eq!(extract_subject_predicate(CHANGE_CREATED_0_3_0), Some(("change","created")));
+//         
 //         assert_eq!(extract_subject_predicate(CHANGE_MERGED_0_1_2), Some(("change","merged")));
+//         
+//         assert_eq!(extract_subject_predicate(CHANGE_MERGED_0_2_0), Some(("change","merged")));
 //         
 //         assert_eq!(extract_subject_predicate(CHANGE_REVIEWED_0_1_2), Some(("change","reviewed")));
 //         
+//         assert_eq!(extract_subject_predicate(CHANGE_REVIEWED_0_2_0), Some(("change","reviewed")));
+//         
 //         assert_eq!(extract_subject_predicate(CHANGE_UPDATED_0_1_2), Some(("change","updated")));
+//         
+//         assert_eq!(extract_subject_predicate(CHANGE_UPDATED_0_2_0), Some(("change","updated")));
 //         
 //         assert_eq!(extract_subject_predicate(ENVIRONMENT_CREATED_0_1_1), Some(("environment","created")));
 //         
+//         assert_eq!(extract_subject_predicate(ENVIRONMENT_CREATED_0_2_0), Some(("environment","created")));
+//         
 //         assert_eq!(extract_subject_predicate(ENVIRONMENT_DELETED_0_1_1), Some(("environment","deleted")));
+//         
+//         assert_eq!(extract_subject_predicate(ENVIRONMENT_DELETED_0_2_0), Some(("environment","deleted")));
 //         
 //         assert_eq!(extract_subject_predicate(ENVIRONMENT_MODIFIED_0_1_1), Some(("environment","modified")));
 //         
+//         assert_eq!(extract_subject_predicate(ENVIRONMENT_MODIFIED_0_2_0), Some(("environment","modified")));
+//         
 //         assert_eq!(extract_subject_predicate(INCIDENT_DETECTED_0_1_0), Some(("incident","detected")));
+//         
+//         assert_eq!(extract_subject_predicate(INCIDENT_DETECTED_0_2_0), Some(("incident","detected")));
 //         
 //         assert_eq!(extract_subject_predicate(INCIDENT_REPORTED_0_1_0), Some(("incident","reported")));
 //         
+//         assert_eq!(extract_subject_predicate(INCIDENT_REPORTED_0_2_0), Some(("incident","reported")));
+//         
 //         assert_eq!(extract_subject_predicate(INCIDENT_RESOLVED_0_1_0), Some(("incident","resolved")));
+//         
+//         assert_eq!(extract_subject_predicate(INCIDENT_RESOLVED_0_2_0), Some(("incident","resolved")));
 //         
 //         assert_eq!(extract_subject_predicate(PIPELINERUN_FINISHED_0_1_1), Some(("pipelinerun","finished")));
 //         
+//         assert_eq!(extract_subject_predicate(PIPELINERUN_FINISHED_0_2_0), Some(("pipelinerun","finished")));
+//         
 //         assert_eq!(extract_subject_predicate(PIPELINERUN_QUEUED_0_1_1), Some(("pipelinerun","queued")));
+//         
+//         assert_eq!(extract_subject_predicate(PIPELINERUN_QUEUED_0_2_0), Some(("pipelinerun","queued")));
 //         
 //         assert_eq!(extract_subject_predicate(PIPELINERUN_STARTED_0_1_1), Some(("pipelinerun","started")));
 //         
+//         assert_eq!(extract_subject_predicate(PIPELINERUN_STARTED_0_2_0), Some(("pipelinerun","started")));
+//         
 //         assert_eq!(extract_subject_predicate(REPOSITORY_CREATED_0_1_1), Some(("repository","created")));
+//         
+//         assert_eq!(extract_subject_predicate(REPOSITORY_CREATED_0_2_0), Some(("repository","created")));
 //         
 //         assert_eq!(extract_subject_predicate(REPOSITORY_DELETED_0_1_1), Some(("repository","deleted")));
 //         
+//         assert_eq!(extract_subject_predicate(REPOSITORY_DELETED_0_2_0), Some(("repository","deleted")));
+//         
 //         assert_eq!(extract_subject_predicate(REPOSITORY_MODIFIED_0_1_1), Some(("repository","modified")));
+//         
+//         assert_eq!(extract_subject_predicate(REPOSITORY_MODIFIED_0_2_0), Some(("repository","modified")));
 //         
 //         assert_eq!(extract_subject_predicate(SERVICE_DEPLOYED_0_1_1), Some(("service","deployed")));
 //         
+//         assert_eq!(extract_subject_predicate(SERVICE_DEPLOYED_0_2_0), Some(("service","deployed")));
+//         
 //         assert_eq!(extract_subject_predicate(SERVICE_PUBLISHED_0_1_1), Some(("service","published")));
+//         
+//         assert_eq!(extract_subject_predicate(SERVICE_PUBLISHED_0_2_0), Some(("service","published")));
 //         
 //         assert_eq!(extract_subject_predicate(SERVICE_REMOVED_0_1_1), Some(("service","removed")));
 //         
+//         assert_eq!(extract_subject_predicate(SERVICE_REMOVED_0_2_0), Some(("service","removed")));
+//         
 //         assert_eq!(extract_subject_predicate(SERVICE_ROLLEDBACK_0_1_1), Some(("service","rolledback")));
+//         
+//         assert_eq!(extract_subject_predicate(SERVICE_ROLLEDBACK_0_2_0), Some(("service","rolledback")));
 //         
 //         assert_eq!(extract_subject_predicate(SERVICE_UPGRADED_0_1_1), Some(("service","upgraded")));
 //         
+//         assert_eq!(extract_subject_predicate(SERVICE_UPGRADED_0_2_0), Some(("service","upgraded")));
+//         
 //         assert_eq!(extract_subject_predicate(TASKRUN_FINISHED_0_1_1), Some(("taskrun","finished")));
+//         
+//         assert_eq!(extract_subject_predicate(TASKRUN_FINISHED_0_2_0), Some(("taskrun","finished")));
 //         
 //         assert_eq!(extract_subject_predicate(TASKRUN_STARTED_0_1_1), Some(("taskrun","started")));
 //         
+//         assert_eq!(extract_subject_predicate(TASKRUN_STARTED_0_2_0), Some(("taskrun","started")));
+//         
 //         assert_eq!(extract_subject_predicate(TESTCASERUN_FINISHED_0_1_0), Some(("testcaserun","finished")));
+//         
+//         assert_eq!(extract_subject_predicate(TESTCASERUN_FINISHED_0_2_0), Some(("testcaserun","finished")));
 //         
 //         assert_eq!(extract_subject_predicate(TESTCASERUN_QUEUED_0_1_0), Some(("testcaserun","queued")));
 //         
+//         assert_eq!(extract_subject_predicate(TESTCASERUN_QUEUED_0_2_0), Some(("testcaserun","queued")));
+//         
+//         assert_eq!(extract_subject_predicate(TESTCASERUN_SKIPPED_0_1_0), Some(("testcaserun","skipped")));
+//         
 //         assert_eq!(extract_subject_predicate(TESTCASERUN_STARTED_0_1_0), Some(("testcaserun","started")));
+//         
+//         assert_eq!(extract_subject_predicate(TESTCASERUN_STARTED_0_2_0), Some(("testcaserun","started")));
 //         
 //         assert_eq!(extract_subject_predicate(TESTOUTPUT_PUBLISHED_0_1_0), Some(("testoutput","published")));
 //         
+//         assert_eq!(extract_subject_predicate(TESTOUTPUT_PUBLISHED_0_2_0), Some(("testoutput","published")));
+//         
 //         assert_eq!(extract_subject_predicate(TESTSUITERUN_FINISHED_0_1_0), Some(("testsuiterun","finished")));
+//         
+//         assert_eq!(extract_subject_predicate(TESTSUITERUN_FINISHED_0_2_0), Some(("testsuiterun","finished")));
 //         
 //         assert_eq!(extract_subject_predicate(TESTSUITERUN_QUEUED_0_1_0), Some(("testsuiterun","queued")));
 //         
+//         assert_eq!(extract_subject_predicate(TESTSUITERUN_QUEUED_0_2_0), Some(("testsuiterun","queued")));
+//         
 //         assert_eq!(extract_subject_predicate(TESTSUITERUN_STARTED_0_1_0), Some(("testsuiterun","started")));
+//         
+//         assert_eq!(extract_subject_predicate(TESTSUITERUN_STARTED_0_2_0), Some(("testsuiterun","started")));
+//         
+//         assert_eq!(extract_subject_predicate(TICKET_CLOSED_0_1_0), Some(("ticket","closed")));
+//         
+//         assert_eq!(extract_subject_predicate(TICKET_CREATED_0_1_0), Some(("ticket","created")));
+//         
+//         assert_eq!(extract_subject_predicate(TICKET_UPDATED_0_1_0), Some(("ticket","updated")));
 //         
 //     }
 // }

--- a/cdevents-sdk/src/generated/mod.rs
+++ b/cdevents-sdk/src/generated/mod.rs
@@ -177,7 +177,46 @@ pub mod spec_0_3_0 {
     pub use super::testsuiterun_queued_0_1_0 as testsuiterun_queued;
     pub use super::testsuiterun_started_0_1_0 as testsuiterun_started;
 }
-pub mod spec_0_4_0 {
+pub mod spec_0_4_0_draft {
+    pub use super::artifact_signed_0_1_0 as artifact_signed;
+    pub use super::branch_created_0_1_2 as branch_created;
+    pub use super::branch_deleted_0_1_2 as branch_deleted;
+    pub use super::build_finished_0_1_1 as build_finished;
+    pub use super::build_queued_0_1_1 as build_queued;
+    pub use super::build_started_0_1_1 as build_started;
+    pub use super::change_abandoned_0_1_2 as change_abandoned;
+    pub use super::change_created_0_2_0 as change_created;
+    pub use super::change_merged_0_1_2 as change_merged;
+    pub use super::change_reviewed_0_1_2 as change_reviewed;
+    pub use super::change_updated_0_1_2 as change_updated;
+    pub use super::environment_created_0_1_1 as environment_created;
+    pub use super::environment_deleted_0_1_1 as environment_deleted;
+    pub use super::environment_modified_0_1_1 as environment_modified;
+    pub use super::incident_detected_0_1_0 as incident_detected;
+    pub use super::incident_reported_0_1_0 as incident_reported;
+    pub use super::incident_resolved_0_1_0 as incident_resolved;
+    pub use super::pipelinerun_finished_0_1_1 as pipelinerun_finished;
+    pub use super::pipelinerun_queued_0_1_1 as pipelinerun_queued;
+    pub use super::pipelinerun_started_0_1_1 as pipelinerun_started;
+    pub use super::repository_created_0_1_1 as repository_created;
+    pub use super::repository_deleted_0_1_1 as repository_deleted;
+    pub use super::repository_modified_0_1_1 as repository_modified;
+    pub use super::service_deployed_0_1_1 as service_deployed;
+    pub use super::service_published_0_1_1 as service_published;
+    pub use super::service_removed_0_1_1 as service_removed;
+    pub use super::service_rolledback_0_1_1 as service_rolledback;
+    pub use super::service_upgraded_0_1_1 as service_upgraded;
+    pub use super::taskrun_finished_0_1_1 as taskrun_finished;
+    pub use super::taskrun_started_0_1_1 as taskrun_started;
+    pub use super::testcaserun_finished_0_1_0 as testcaserun_finished;
+    pub use super::testcaserun_queued_0_1_0 as testcaserun_queued;
+    pub use super::testcaserun_started_0_1_0 as testcaserun_started;
+    pub use super::testoutput_published_0_1_0 as testoutput_published;
+    pub use super::testsuiterun_finished_0_1_0 as testsuiterun_finished;
+    pub use super::testsuiterun_queued_0_1_0 as testsuiterun_queued;
+    pub use super::testsuiterun_started_0_1_0 as testsuiterun_started;
+}
+pub mod spec_0_4_1 {
     pub use super::artifact_deleted_0_1_0 as artifact_deleted;
     pub use super::artifact_downloaded_0_1_0 as artifact_downloaded;
     pub use super::artifact_packaged_0_2_0 as artifact_packaged;
@@ -223,45 +262,6 @@ pub mod spec_0_4_0 {
     pub use super::ticket_closed_0_1_0 as ticket_closed;
     pub use super::ticket_created_0_1_0 as ticket_created;
     pub use super::ticket_updated_0_1_0 as ticket_updated;
-}
-pub mod spec_0_4_0_draft {
-    pub use super::artifact_signed_0_1_0 as artifact_signed;
-    pub use super::branch_created_0_1_2 as branch_created;
-    pub use super::branch_deleted_0_1_2 as branch_deleted;
-    pub use super::build_finished_0_1_1 as build_finished;
-    pub use super::build_queued_0_1_1 as build_queued;
-    pub use super::build_started_0_1_1 as build_started;
-    pub use super::change_abandoned_0_1_2 as change_abandoned;
-    pub use super::change_created_0_2_0 as change_created;
-    pub use super::change_merged_0_1_2 as change_merged;
-    pub use super::change_reviewed_0_1_2 as change_reviewed;
-    pub use super::change_updated_0_1_2 as change_updated;
-    pub use super::environment_created_0_1_1 as environment_created;
-    pub use super::environment_deleted_0_1_1 as environment_deleted;
-    pub use super::environment_modified_0_1_1 as environment_modified;
-    pub use super::incident_detected_0_1_0 as incident_detected;
-    pub use super::incident_reported_0_1_0 as incident_reported;
-    pub use super::incident_resolved_0_1_0 as incident_resolved;
-    pub use super::pipelinerun_finished_0_1_1 as pipelinerun_finished;
-    pub use super::pipelinerun_queued_0_1_1 as pipelinerun_queued;
-    pub use super::pipelinerun_started_0_1_1 as pipelinerun_started;
-    pub use super::repository_created_0_1_1 as repository_created;
-    pub use super::repository_deleted_0_1_1 as repository_deleted;
-    pub use super::repository_modified_0_1_1 as repository_modified;
-    pub use super::service_deployed_0_1_1 as service_deployed;
-    pub use super::service_published_0_1_1 as service_published;
-    pub use super::service_removed_0_1_1 as service_removed;
-    pub use super::service_rolledback_0_1_1 as service_rolledback;
-    pub use super::service_upgraded_0_1_1 as service_upgraded;
-    pub use super::taskrun_finished_0_1_1 as taskrun_finished;
-    pub use super::taskrun_started_0_1_1 as taskrun_started;
-    pub use super::testcaserun_finished_0_1_0 as testcaserun_finished;
-    pub use super::testcaserun_queued_0_1_0 as testcaserun_queued;
-    pub use super::testcaserun_started_0_1_0 as testcaserun_started;
-    pub use super::testoutput_published_0_1_0 as testoutput_published;
-    pub use super::testsuiterun_finished_0_1_0 as testsuiterun_finished;
-    pub use super::testsuiterun_queued_0_1_0 as testsuiterun_queued;
-    pub use super::testsuiterun_started_0_1_0 as testsuiterun_started;
 }
 
 pub const ARTIFACT_DELETED_0_1_0: &str = "dev.cdevents.artifact.deleted.0.1.0";

--- a/cdevents-sdk/src/generated/pipelinerun_finished_0_2_0.rs
+++ b/cdevents-sdk/src/generated/pipelinerun_finished_0_2_0.rs
@@ -1,0 +1,35 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "errors", default, skip_serializing_if = "Option::is_none",)]
+    pub errors: Option<String>,
+    #[serde(rename = "outcome", default, skip_serializing_if = "Option::is_none",)]
+    pub outcome: Option<String>,
+    #[serde(rename = "pipelineName", default, skip_serializing_if = "Option::is_none",)]
+    pub pipeline_name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/pipelinerun_queued_0_2_0.rs
+++ b/cdevents-sdk/src/generated/pipelinerun_queued_0_2_0.rs
@@ -1,0 +1,31 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "pipelineName", default, skip_serializing_if = "Option::is_none",)]
+    pub pipeline_name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/pipelinerun_started_0_2_0.rs
+++ b/cdevents-sdk/src/generated/pipelinerun_started_0_2_0.rs
@@ -1,0 +1,31 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "pipelineName",)]
+    pub pipeline_name: String,
+    #[serde(rename = "url",)]
+    pub url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/repository_created_0_2_0.rs
+++ b/cdevents-sdk/src/generated/repository_created_0_2_0.rs
@@ -1,0 +1,35 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "name",)]
+    pub name: crate::Name,
+    #[serde(rename = "owner", default, skip_serializing_if = "Option::is_none",)]
+    pub owner: Option<String>,
+    #[serde(rename = "url",)]
+    pub url: crate::Uri,
+    #[serde(rename = "viewUrl", default, skip_serializing_if = "Option::is_none",)]
+    pub view_url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/repository_deleted_0_2_0.rs
+++ b/cdevents-sdk/src/generated/repository_deleted_0_2_0.rs
@@ -1,0 +1,35 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "owner", default, skip_serializing_if = "Option::is_none",)]
+    pub owner: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+    #[serde(rename = "viewUrl", default, skip_serializing_if = "Option::is_none",)]
+    pub view_url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/repository_modified_0_2_0.rs
+++ b/cdevents-sdk/src/generated/repository_modified_0_2_0.rs
@@ -1,0 +1,35 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "owner", default, skip_serializing_if = "Option::is_none",)]
+    pub owner: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+    #[serde(rename = "viewUrl", default, skip_serializing_if = "Option::is_none",)]
+    pub view_url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/service_deployed_0_2_0.rs
+++ b/cdevents-sdk/src/generated/service_deployed_0_2_0.rs
@@ -1,0 +1,41 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId",)]
+    pub artifact_id: crate::Id,
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/service_published_0_2_0.rs
+++ b/cdevents-sdk/src/generated/service_published_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment", default, skip_serializing_if = "Option::is_none",)]
+    pub environment: Option<ContentEnvironment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/service_removed_0_2_0.rs
+++ b/cdevents-sdk/src/generated/service_removed_0_2_0.rs
@@ -1,0 +1,39 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment", default, skip_serializing_if = "Option::is_none",)]
+    pub environment: Option<ContentEnvironment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/service_rolledback_0_2_0.rs
+++ b/cdevents-sdk/src/generated/service_rolledback_0_2_0.rs
@@ -1,0 +1,41 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId",)]
+    pub artifact_id: crate::Id,
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/service_upgraded_0_2_0.rs
+++ b/cdevents-sdk/src/generated/service_upgraded_0_2_0.rs
@@ -1,0 +1,41 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "artifactId",)]
+    pub artifact_id: crate::Id,
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/taskrun_finished_0_2_0.rs
+++ b/cdevents-sdk/src/generated/taskrun_finished_0_2_0.rs
@@ -1,0 +1,47 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "errors", default, skip_serializing_if = "Option::is_none",)]
+    pub errors: Option<String>,
+    #[serde(rename = "outcome", default, skip_serializing_if = "Option::is_none",)]
+    pub outcome: Option<String>,
+    #[serde(rename = "pipelineRun", default, skip_serializing_if = "Option::is_none",)]
+    pub pipeline_run: Option<ContentPipelineRun>,
+    #[serde(rename = "taskName", default, skip_serializing_if = "Option::is_none",)]
+    pub task_name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentPipelineRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/taskrun_started_0_2_0.rs
+++ b/cdevents-sdk/src/generated/taskrun_started_0_2_0.rs
@@ -1,0 +1,43 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "pipelineRun", default, skip_serializing_if = "Option::is_none",)]
+    pub pipeline_run: Option<ContentPipelineRun>,
+    #[serde(rename = "taskName", default, skip_serializing_if = "Option::is_none",)]
+    pub task_name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentPipelineRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testcaserun_finished_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testcaserun_finished_0_2_0.rs
@@ -1,0 +1,122 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "outcome",)]
+    pub outcome: ContentOutcome,
+    #[serde(rename = "reason", default, skip_serializing_if = "Option::is_none",)]
+    pub reason: Option<String>,
+    #[serde(rename = "severity", default, skip_serializing_if = "Option::is_none",)]
+    pub severity: Option<ContentSeverity>,
+    #[serde(rename = "testCase", default, skip_serializing_if = "Option::is_none",)]
+    pub test_case: Option<ContentTestCase>,
+    #[serde(rename = "testSuiteRun", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite_run: Option<ContentTestSuiteRun>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuiteRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestCase {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTestCaseType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentOutcome {
+    #[serde(rename = "pass")]
+    Pass,
+    #[serde(rename = "fail")]
+    Fail,
+    #[serde(rename = "cancel")]
+    Cancel,
+    #[serde(rename = "error")]
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentSeverity {
+    #[serde(rename = "low")]
+    Low,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "high")]
+    High,
+    #[serde(rename = "critical")]
+    Critical,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTestCaseType {
+    #[serde(rename = "performance")]
+    Performance,
+    #[serde(rename = "functional")]
+    Functional,
+    #[serde(rename = "unit")]
+    Unit,
+    #[serde(rename = "security")]
+    Security,
+    #[serde(rename = "compliance")]
+    Compliance,
+    #[serde(rename = "integration")]
+    Integration,
+    #[serde(rename = "e2e")]
+    E2E,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testcaserun_queued_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testcaserun_queued_0_2_0.rs
@@ -1,0 +1,117 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "testCase", default, skip_serializing_if = "Option::is_none",)]
+    pub test_case: Option<ContentTestCase>,
+    #[serde(rename = "testSuiteRun", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite_run: Option<ContentTestSuiteRun>,
+    #[serde(rename = "trigger", default, skip_serializing_if = "Option::is_none",)]
+    pub trigger: Option<ContentTrigger>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTrigger {
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTriggerType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuiteRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestCase {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTestCaseType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTestCaseType {
+    #[serde(rename = "performance")]
+    Performance,
+    #[serde(rename = "functional")]
+    Functional,
+    #[serde(rename = "unit")]
+    Unit,
+    #[serde(rename = "security")]
+    Security,
+    #[serde(rename = "compliance")]
+    Compliance,
+    #[serde(rename = "integration")]
+    Integration,
+    #[serde(rename = "e2e")]
+    E2E,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTriggerType {
+    #[serde(rename = "manual")]
+    Manual,
+    #[serde(rename = "pipeline")]
+    Pipeline,
+    #[serde(rename = "event")]
+    Event,
+    #[serde(rename = "schedule")]
+    Schedule,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testcaserun_skipped_0_1_0.rs
+++ b/cdevents-sdk/src/generated/testcaserun_skipped_0_1_0.rs
@@ -1,0 +1,92 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment", default, skip_serializing_if = "Option::is_none",)]
+    pub environment: Option<ContentEnvironment>,
+    #[serde(rename = "reason", default, skip_serializing_if = "Option::is_none",)]
+    pub reason: Option<String>,
+    #[serde(rename = "testCase", default, skip_serializing_if = "Option::is_none",)]
+    pub test_case: Option<ContentTestCase>,
+    #[serde(rename = "testSuiteRun", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite_run: Option<ContentTestSuiteRun>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuiteRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestCase {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTestCaseType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTestCaseType {
+    #[serde(rename = "performance")]
+    Performance,
+    #[serde(rename = "functional")]
+    Functional,
+    #[serde(rename = "unit")]
+    Unit,
+    #[serde(rename = "security")]
+    Security,
+    #[serde(rename = "compliance")]
+    Compliance,
+    #[serde(rename = "integration")]
+    Integration,
+    #[serde(rename = "e2e")]
+    E2E,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testcaserun_started_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testcaserun_started_0_2_0.rs
@@ -1,0 +1,117 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "testCase", default, skip_serializing_if = "Option::is_none",)]
+    pub test_case: Option<ContentTestCase>,
+    #[serde(rename = "testSuiteRun", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite_run: Option<ContentTestSuiteRun>,
+    #[serde(rename = "trigger", default, skip_serializing_if = "Option::is_none",)]
+    pub trigger: Option<ContentTrigger>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTrigger {
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTriggerType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuiteRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestCase {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTestCaseType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTestCaseType {
+    #[serde(rename = "performance")]
+    Performance,
+    #[serde(rename = "functional")]
+    Functional,
+    #[serde(rename = "unit")]
+    Unit,
+    #[serde(rename = "security")]
+    Security,
+    #[serde(rename = "compliance")]
+    Compliance,
+    #[serde(rename = "integration")]
+    Integration,
+    #[serde(rename = "e2e")]
+    E2E,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTriggerType {
+    #[serde(rename = "manual")]
+    Manual,
+    #[serde(rename = "pipeline")]
+    Pipeline,
+    #[serde(rename = "event")]
+    Event,
+    #[serde(rename = "schedule")]
+    Schedule,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testoutput_published_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testoutput_published_0_2_0.rs
@@ -1,0 +1,60 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "format",)]
+    pub format: String,
+    #[serde(rename = "outputType",)]
+    pub output_type: ContentOutputType,
+    #[serde(rename = "testCaseRun", default, skip_serializing_if = "Option::is_none",)]
+    pub test_case_run: Option<ContentTestCaseRun>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestCaseRun {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentOutputType {
+    #[serde(rename = "report")]
+    Report,
+    #[serde(rename = "video")]
+    Video,
+    #[serde(rename = "image")]
+    Image,
+    #[serde(rename = "log")]
+    Log,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testsuiterun_finished_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testsuiterun_finished_0_2_0.rs
@@ -1,0 +1,87 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "outcome",)]
+    pub outcome: ContentOutcome,
+    #[serde(rename = "reason", default, skip_serializing_if = "Option::is_none",)]
+    pub reason: Option<String>,
+    #[serde(rename = "severity", default, skip_serializing_if = "Option::is_none",)]
+    pub severity: Option<ContentSeverity>,
+    #[serde(rename = "testSuite", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite: Option<ContentTestSuite>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuite {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentOutcome {
+    #[serde(rename = "pass")]
+    Pass,
+    #[serde(rename = "fail")]
+    Fail,
+    #[serde(rename = "cancel")]
+    Cancel,
+    #[serde(rename = "error")]
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentSeverity {
+    #[serde(rename = "low")]
+    Low,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "high")]
+    High,
+    #[serde(rename = "critical")]
+    Critical,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testsuiterun_queued_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testsuiterun_queued_0_2_0.rs
@@ -1,0 +1,82 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "testSuite", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite: Option<ContentTestSuite>,
+    #[serde(rename = "trigger", default, skip_serializing_if = "Option::is_none",)]
+    pub trigger: Option<ContentTrigger>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTrigger {
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTriggerType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuite {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none",)]
+    pub url: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTriggerType {
+    #[serde(rename = "manual")]
+    Manual,
+    #[serde(rename = "pipeline")]
+    Pipeline,
+    #[serde(rename = "event")]
+    Event,
+    #[serde(rename = "schedule")]
+    Schedule,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/testsuiterun_started_0_2_0.rs
+++ b/cdevents-sdk/src/generated/testsuiterun_started_0_2_0.rs
@@ -1,0 +1,82 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "environment",)]
+    pub environment: ContentEnvironment,
+    #[serde(rename = "testSuite", default, skip_serializing_if = "Option::is_none",)]
+    pub test_suite: Option<ContentTestSuite>,
+    #[serde(rename = "trigger", default, skip_serializing_if = "Option::is_none",)]
+    pub trigger: Option<ContentTrigger>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTrigger {
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none",)]
+    pub ty: Option<ContentTriggerType>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentTestSuite {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "name", default, skip_serializing_if = "Option::is_none",)]
+    pub name: Option<String>,
+    #[serde(rename = "uri", default, skip_serializing_if = "Option::is_none",)]
+    pub uri: Option<crate::Uri>,
+    #[serde(rename = "version", default, skip_serializing_if = "Option::is_none",)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ContentEnvironment {
+    #[serde(rename = "id",)]
+    pub id: crate::Id,
+    #[serde(rename = "source", default, skip_serializing_if = "Option::is_none",)]
+    pub source: Option<crate::UriReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+pub enum ContentTriggerType {
+    #[serde(rename = "manual")]
+    Manual,
+    #[serde(rename = "pipeline")]
+    Pipeline,
+    #[serde(rename = "event")]
+    Event,
+    #[serde(rename = "schedule")]
+    Schedule,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/ticket_closed_0_1_0.rs
+++ b/cdevents-sdk/src/generated/ticket_closed_0_1_0.rs
@@ -1,0 +1,49 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "assignees", default, skip_serializing_if = "Option::is_none",)]
+    pub assignees: Option<Vec<String>>,
+    #[serde(rename = "creator", default, skip_serializing_if = "Option::is_none",)]
+    pub creator: Option<crate::NonEmptyString>,
+    #[serde(rename = "group", default, skip_serializing_if = "Option::is_none",)]
+    pub group: Option<String>,
+    #[serde(rename = "labels", default, skip_serializing_if = "Option::is_none",)]
+    pub labels: Option<Vec<String>>,
+    #[serde(rename = "milestone", default, skip_serializing_if = "Option::is_none",)]
+    pub milestone: Option<String>,
+    #[serde(rename = "priority", default, skip_serializing_if = "Option::is_none",)]
+    pub priority: Option<String>,
+    #[serde(rename = "resolution",)]
+    pub resolution: String,
+    #[serde(rename = "summary", default, skip_serializing_if = "Option::is_none",)]
+    pub summary: Option<String>,
+    #[serde(rename = "ticketType", default, skip_serializing_if = "Option::is_none",)]
+    pub ticket_type: Option<String>,
+    #[serde(rename = "updatedBy", default, skip_serializing_if = "Option::is_none",)]
+    pub updated_by: Option<String>,
+    #[serde(rename = "uri",)]
+    pub uri: crate::UriReference,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/ticket_closed_0_1_0.rs
+++ b/cdevents-sdk/src/generated/ticket_closed_0_1_0.rs
@@ -19,13 +19,13 @@ pub struct Content {
     #[serde(rename = "milestone", default, skip_serializing_if = "Option::is_none",)]
     pub milestone: Option<String>,
     #[serde(rename = "priority", default, skip_serializing_if = "Option::is_none",)]
-    pub priority: Option<String>,
+    pub priority: Option<crate::NonEmptyString>,
     #[serde(rename = "resolution",)]
-    pub resolution: String,
+    pub resolution: crate::NonEmptyString,
     #[serde(rename = "summary", default, skip_serializing_if = "Option::is_none",)]
     pub summary: Option<String>,
     #[serde(rename = "ticketType", default, skip_serializing_if = "Option::is_none",)]
-    pub ticket_type: Option<String>,
+    pub ticket_type: Option<crate::NonEmptyString>,
     #[serde(rename = "updatedBy", default, skip_serializing_if = "Option::is_none",)]
     pub updated_by: Option<String>,
     #[serde(rename = "uri",)]

--- a/cdevents-sdk/src/generated/ticket_created_0_1_0.rs
+++ b/cdevents-sdk/src/generated/ticket_created_0_1_0.rs
@@ -1,0 +1,45 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "assignees", default, skip_serializing_if = "Option::is_none",)]
+    pub assignees: Option<Vec<String>>,
+    #[serde(rename = "creator",)]
+    pub creator: crate::NonEmptyString,
+    #[serde(rename = "group", default, skip_serializing_if = "Option::is_none",)]
+    pub group: Option<String>,
+    #[serde(rename = "labels", default, skip_serializing_if = "Option::is_none",)]
+    pub labels: Option<Vec<String>>,
+    #[serde(rename = "milestone", default, skip_serializing_if = "Option::is_none",)]
+    pub milestone: Option<String>,
+    #[serde(rename = "priority", default, skip_serializing_if = "Option::is_none",)]
+    pub priority: Option<String>,
+    #[serde(rename = "summary",)]
+    pub summary: String,
+    #[serde(rename = "ticketType", default, skip_serializing_if = "Option::is_none",)]
+    pub ticket_type: Option<String>,
+    #[serde(rename = "uri",)]
+    pub uri: crate::UriReference,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/src/generated/ticket_created_0_1_0.rs
+++ b/cdevents-sdk/src/generated/ticket_created_0_1_0.rs
@@ -19,11 +19,11 @@ pub struct Content {
     #[serde(rename = "milestone", default, skip_serializing_if = "Option::is_none",)]
     pub milestone: Option<String>,
     #[serde(rename = "priority", default, skip_serializing_if = "Option::is_none",)]
-    pub priority: Option<String>,
+    pub priority: Option<crate::NonEmptyString>,
     #[serde(rename = "summary",)]
     pub summary: String,
     #[serde(rename = "ticketType", default, skip_serializing_if = "Option::is_none",)]
-    pub ticket_type: Option<String>,
+    pub ticket_type: Option<crate::NonEmptyString>,
     #[serde(rename = "uri",)]
     pub uri: crate::UriReference,
 }

--- a/cdevents-sdk/src/generated/ticket_updated_0_1_0.rs
+++ b/cdevents-sdk/src/generated/ticket_updated_0_1_0.rs
@@ -19,11 +19,11 @@ pub struct Content {
     #[serde(rename = "milestone", default, skip_serializing_if = "Option::is_none",)]
     pub milestone: Option<String>,
     #[serde(rename = "priority", default, skip_serializing_if = "Option::is_none",)]
-    pub priority: Option<String>,
+    pub priority: Option<crate::NonEmptyString>,
     #[serde(rename = "summary", default, skip_serializing_if = "Option::is_none",)]
     pub summary: Option<String>,
     #[serde(rename = "ticketType", default, skip_serializing_if = "Option::is_none",)]
-    pub ticket_type: Option<String>,
+    pub ticket_type: Option<crate::NonEmptyString>,
     #[serde(rename = "updatedBy", default, skip_serializing_if = "Option::is_none",)]
     pub updated_by: Option<String>,
     #[serde(rename = "uri",)]

--- a/cdevents-sdk/src/generated/ticket_updated_0_1_0.rs
+++ b/cdevents-sdk/src/generated/ticket_updated_0_1_0.rs
@@ -1,0 +1,47 @@
+// @generated
+// by cdevents/sdk-rust/generator (subject.hbs)
+
+#[cfg(feature = "testkit")] use proptest_derive::Arbitrary;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "testkit", derive(Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct Content {
+    #[serde(rename = "assignees", default, skip_serializing_if = "Option::is_none",)]
+    pub assignees: Option<Vec<String>>,
+    #[serde(rename = "creator", default, skip_serializing_if = "Option::is_none",)]
+    pub creator: Option<crate::NonEmptyString>,
+    #[serde(rename = "group", default, skip_serializing_if = "Option::is_none",)]
+    pub group: Option<String>,
+    #[serde(rename = "labels", default, skip_serializing_if = "Option::is_none",)]
+    pub labels: Option<Vec<String>>,
+    #[serde(rename = "milestone", default, skip_serializing_if = "Option::is_none",)]
+    pub milestone: Option<String>,
+    #[serde(rename = "priority", default, skip_serializing_if = "Option::is_none",)]
+    pub priority: Option<String>,
+    #[serde(rename = "summary", default, skip_serializing_if = "Option::is_none",)]
+    pub summary: Option<String>,
+    #[serde(rename = "ticketType", default, skip_serializing_if = "Option::is_none",)]
+    pub ticket_type: Option<String>,
+    #[serde(rename = "updatedBy", default, skip_serializing_if = "Option::is_none",)]
+    pub updated_by: Option<String>,
+    #[serde(rename = "uri",)]
+    pub uri: crate::UriReference,
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[cfg(feature = "testkit")]
+        fn arbitraries_are_json_valid(s in any::<Content>()) {
+            let json_str = serde_json::to_string(&s).unwrap();
+            let actual = serde_json::from_str::<Content>(&json_str).unwrap();
+            assert_eq!(s, actual);
+        }
+    }
+}

--- a/cdevents-sdk/tests/specs.rs
+++ b/cdevents-sdk/tests/specs.rs
@@ -4,7 +4,7 @@ use rstest::*;
 use std::{collections::HashMap, fs};
 use std::path::PathBuf;
 use proptest::prelude::*;
-use boon::{Schemas, Compiler, SchemaIndex};
+use boon::{Compiler, SchemaIndex, Schemas, UrlLoader};
 use glob::glob;
 use std::sync::OnceLock;
 
@@ -18,6 +18,10 @@ impl EventsSchemas {
         let mut schemas = Schemas::new();
         let mut compiler = Compiler::new();
         let mut mapping = HashMap::new();
+
+        //HACK to resolve invalid `$ref: "/schema/links/embeddedlinksarray.json"`
+        compiler.register_url_loader("https", Box::new(HackUrlLoader{}));
+
         for entry in glob("../cdevents-specs/*/schemas/*.json").expect("Failed to read glob pattern") {
             let schemapath = entry.unwrap();
             //TODO avoid to read the schema twice (as json, then as jsonschema)
@@ -47,6 +51,19 @@ impl EventsSchemas {
     }
 }
 
+struct HackUrlLoader;
+
+impl UrlLoader for HackUrlLoader {
+    fn load(&self, url: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+        if url.starts_with("https://cdevents.dev/schema/links/") {
+            let path = url.replace("https://cdevents.dev/schema", "../cdevents-specs/spec-v0.4/schemas/");
+            let jsonschema: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+            Ok(jsonschema)
+        } else {
+            Err(format!("fail to load {url}").into())
+        }
+    }
+}
 static EVENTS_SCHEMA_CELL: OnceLock<EventsSchemas> = OnceLock::new();
 
 fn events_schemas() -> &'static EventsSchemas { 
@@ -54,7 +71,7 @@ fn events_schemas() -> &'static EventsSchemas {
 }
 
 #[rstest]
-fn for_each_example(#[files("../cdevents-specs/spec-v0.3/examples/*.json")] path: PathBuf) {
+fn can_serde_example(#[files("../cdevents-specs/spec-*/examples/*.json")] path: PathBuf) {
     let example_txt = fs::read_to_string(path).expect("to read file as string");
     //HACK uri are stored ad http::Uri, they are "normalized" when serialized, so prenormalization to avoid failure like
     // json atoms at path ".subject.content.repository.source" are not equal:
@@ -78,7 +95,7 @@ fn for_each_example(#[files("../cdevents-specs/spec-v0.3/examples/*.json")] path
 }
 
 #[rstest]
-fn validate_example_against_schema(#[files("../cdevents-specs/spec-v0.3/examples/*.json")] path: PathBuf) {
+fn validate_example_against_schema(#[files("../cdevents-specs/spec-*/examples/*.json")] path: PathBuf) {
     let events_schemas = events_schemas();
     let example_txt = fs::read_to_string(path).expect("to read file as string");
     let example_json: serde_json::Value =

--- a/cdevents-sdk/tests/specs.rs
+++ b/cdevents-sdk/tests/specs.rs
@@ -78,7 +78,7 @@ fn events_schemas() -> &'static EventsSchemas {
 }
 
 #[rstest]
-fn can_serde_example(#[files("../cdevents-specs/spec-*/examples/*.json")] path: PathBuf) {
+fn can_serde_example(#[files("../cdevents-specs/spec-*/examples/*.json")] #[files("../cdevents-specs/spec-*/conformance/*.json")] path: PathBuf) {
     let example_txt = fs::read_to_string(path).expect("to read file as string");
     // HACK uri are stored ad http::Uri, they are "normalized" when serialized, so prenormalization to avoid failure like
     // json atoms at path ".subject.content.repository.source" are not equal:
@@ -102,7 +102,7 @@ fn can_serde_example(#[files("../cdevents-specs/spec-*/examples/*.json")] path: 
 }
 
 #[rstest]
-fn validate_example_against_schema(#[files("../cdevents-specs/spec-*/examples/*.json")] path: PathBuf) {
+fn validate_example_against_schema(#[files("../cdevents-specs/spec-*/examples/*.json")] #[files("../cdevents-specs/spec-*/conformance/*.json")] path: PathBuf) {
     let events_schemas = events_schemas();
     let example_txt = fs::read_to_string(path).expect("to read file as string");
     let example_json: serde_json::Value =

--- a/cdevents-sdk/tests/specs.rs
+++ b/cdevents-sdk/tests/specs.rs
@@ -20,7 +20,7 @@ impl EventsSchemas {
         let mut mapping = HashMap::new();
 
         //HACK to resolve invalid `$ref: "/schema/links/embeddedlinksarray.json"`
-        compiler.register_url_loader("https", Box::new(HackUrlLoader{}));
+        compiler.use_loader(Box::new(HackUrlLoader{}));
 
         for entry in glob("../cdevents-specs/*/schemas/*.json").expect("Failed to read glob pattern") {
             let schemapath = entry.unwrap();
@@ -64,6 +64,10 @@ impl UrlLoader for HackUrlLoader {
             // HACK to fix a bug in specs 0.4.0
             // [Link's ref path needs an update for all the event schemas · Issue #211 · cdevents/spec](https://github.com/cdevents/spec/issues/211)
             let path = url.replace("https://cdevents.dev/schema", "../cdevents-specs/spec-v0.4/schemas/");
+            let jsonschema: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+            Ok(jsonschema)
+        } else if url.starts_with("file://") {
+            let path = url.replace("file://", "");
             let jsonschema: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(path)?)?;
             Ok(jsonschema)
         } else {

--- a/generator/README.md
+++ b/generator/README.md
@@ -13,9 +13,9 @@ Goals: generate rust code for cdevents from jsonschema provided as part of cdeve
 
 ## Run
 
-To generate the `subjects` into sibling crate `cdevents/src/generated` from content of `cdevents-specs/spec-v0.3/schemas`, from root workspace
+To generate the `subjects` into sibling crate `cdevents/src/generated` from content of `cdevents-specs/spec-v0.4/schemas`, from root workspace
 
 ```sh
 cargo run -p generator -- --help
-cargo run -p generator -- --templates-dir "generator/templates" --jsonschema-dir "cdevents-specs/spec-v0.3/schemas" --dest "cdevents-sdk/src/generated"
+cargo run -p generator -- --templates-dir "generator/templates" --jsonschema-dir "cdevents-specs/spec-v0.4/schemas" --dest "cdevents-sdk/src/generated"
 ```

--- a/generator/README.md
+++ b/generator/README.md
@@ -4,16 +4,16 @@ Goals: generate rust code for cdevents from jsonschema provided as part of cdeve
 
 - The generator take read jsonschema as json apply them to a set of templates
 - The generator is very basic (no json schema semantic, no `$ref` resolution) like [eventuallyconsultant/codegenr: Fast handlebars templates based code generator, ingesting swagger/openapi and other json/yaml documents with $refs, or graphql schema, outputs whatever you template](https://github.com/eventuallyconsultant/codegenr/)
-- The generator is currently used to generated Subjects
+- The generator is currently used to generate Subjects
 
 ## Why not use a jsonschema to rust generator?
 
-- I tried some and they failed (no error), maybe too early, not support for the version of jsonschema used by cdevents (often they support jsonschema draft-4)
-- The json schema (v0.3) are not connected, so lot of duplication (context,...), so classical generators will create as many Context type as Event type,... Our implementation only part of the schema is extracted to generate what is different aka the `content` of subjects.
+- I tried some and they failed (no error), maybe too early, or do not support the version of jsonschema used by cdevents (often they support jsonschema draft-4)
+- The jsonschemas (v0.3) are not connected (a set of independent schemas), so a lot of duplication (context,...), so classical generators will create as many Context types as Event types,... In our implementation, only parts of the schema are extracted to generate what is different aka the `content` of subjects.
 
 ## Run
 
-To generate the `subjects` into sibling crate `cdevents/src/generated` from content of `cdevents-specs/spec-v0.4/schemas`, from root workspace
+To generate the `subjects` into sibling crate `cdevents/src/generated` from the content of `cdevents-specs/spec-v0.4/schemas`, from the root workspace
 
 ```sh
 cargo run -p generator -- --help

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -328,8 +328,30 @@ fn collect_structs(
                 type_info
             }
         },
-        Some(x) => todo!("impl for type='{}'", x),
-        None => unimplemented!("expected key 'type' in field '{}'", field_names.join(".")),
+        // Some("array") => TypeInfo {
+        //     type_declaration: "serde_json::Array<serde_json::Value>".to_string(),
+        //     ..Default::default()
+        // },
+        Some(x) => match field_names.last() {
+            // HACK for array of string
+            Some(&"assignees") | Some(&"labels") => TypeInfo {
+                type_declaration: "Vec<String>".to_string(),
+                ..Default::default()
+            },
+            _ => todo!(
+                "impl for type='{}' for field='{}'",
+                x,
+                field_names.join(".")
+            ),
+        },
+        None => match field_names.last() {
+            // HACK for an anyOf (string or enum/string)
+            Some(&"priority") | Some(&"ticketType") | Some(&"resolution") => TypeInfo {
+                type_declaration: "String".to_string(),
+                ..Default::default()
+            },
+            _ => unimplemented!("expected key 'type' in field '{}'", field_names.join(".")),
+        },
     }
 }
 

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -347,7 +347,7 @@ fn collect_structs(
         None => match field_names.last() {
             // HACK for an anyOf (string or enum/string)
             Some(&"priority") | Some(&"ticketType") | Some(&"resolution") => TypeInfo {
-                type_declaration: "String".to_string(),
+                type_declaration: "crate::NonEmptyString".to_string(),
                 ..Default::default()
             },
             _ => unimplemented!("expected key 'type' in field '{}'", field_names.join(".")),


### PR DESCRIPTION
- with some hack, shortcut to improve
- content of src/generated is pushed into a sepated commit 

I include into the Makefile, as commented target, how to create, add spec, it's for documentation and for command to edit/run for each spec to add.

reminder: content of .../generated could be skipped or quickly reviewed (except mod.rs)