### PR TITLE
fix: configuration error on cargo-deny

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,9 +7,9 @@ permissions:
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -29,9 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check Commit Lint
-        with:
-          configFile: "./.commitlint.config.js"
-        uses: wagoid/commitlint-github-action@v6.0.1
+        uses: wagoid/commitlint-github-action@v6
 
   lint_check:
     name: Rust - lint_${{ matrix.lint_projects }}
@@ -63,14 +61,14 @@ jobs:
         uses: actions/cache@v4
         continue-on-error: false
         with:
-            path: |
-              ~/.cargo/bin
-              ~/.cargo/registry
-              ~/.cargo/git/db/
-            key: ${{ runner.os }}-sdk-rust-${{ hashFiles('**/Cargo.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-sdk-rust-
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-sdk-rust-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sdk-rust-
       - name: Check cargo version
         run: cargo --version
       - name: Run ${{ matrix.lint_projects }}
-        run:  make -f Makefile lint_${{ matrix.lint_projects }}
+        run: make -f Makefile lint_${{ matrix.lint_projects }}

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,11 +1,11 @@
-module.exports = {
+export default {
     parserPreset: 'conventional-changelog-conventionalcommits',
     rules: {
         'body-leading-blank': [1, 'always'],
-        'body-max-line-length': [2, 'always', 100],
+        'body-max-line-length': [2, 'always', 140],
         'footer-leading-blank': [1, 'always'],
-        'footer-max-line-length': [2, 'always', 100],
-        'header-max-length': [2, 'always', 100],
+        'footer-max-line-length': [2, 'always', 140],
+        'header-max-length': [2, 'always', 140],
         'subject-case': [
             2,
             'never',

--- a/tools/cargo-deny/deny.toml
+++ b/tools/cargo-deny/deny.toml
@@ -6,10 +6,8 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
 confidence-threshold = 0.95
-allow = ["Apache-2.0", "MIT", "BSD-2-Clause", "Unicode-DFS-2016"]
+allow = ["Apache-2.0", "MIT", "Unicode-DFS-2016"]
 exceptions = []
 
 # The unpublished packages (generator) would be ignored now
@@ -18,8 +16,6 @@ exceptions = []
 ignore = true
 
 [advisories]
-unmaintained = "deny"
-vulnerability = "deny"
 yanked = "warn"
 # Users who require or prefer Git to use SSH cloning instead of HTTPS,
 # such as implemented via "insteadOf" rules in Git config, can still


### PR DESCRIPTION
see: [Add version = 2 by Jake-Shadle · Pull Request #611 · EmbarkStudios/cargo-deny](https://github.com/EmbarkStudios/cargo-deny/pull/611)

previously
```
warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /mnt/nvme0n1p1/david/src/github.com/cdevents/sdk-rust/tools/cargo-deny/deny.toml:22:1
   │
22 │ vulnerability = "deny"
   │ ^^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /mnt/nvme0n1p1/david/src/github.com/cdevents/sdk-rust/tools/cargo-deny/deny.toml:21:1
   │
21 │ unmaintained = "deny"
   │ ^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /mnt/nvme0n1p1/david/src/github.com/cdevents/sdk-rust/tools/cargo-deny/deny.toml:9:1
  │
9 │ unlicensed = "deny"
  │ ^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /mnt/nvme0n1p1/david/src/github.com/cdevents/sdk-rust/tools/cargo-deny/deny.toml:10:1
   │
10 │ copyleft = "deny"
   │ ^^^^^^^^

warning[license-not-encountered]: license was not encountered
   ┌─ /mnt/nvme0n1p1/david/src/github.com/cdevents/sdk-rust/tools/cargo-deny/deny.toml:12:32
   │
12 │ allow = ["Apache-2.0", "MIT", "BSD-2-Clause", "Unicode-DFS-2016"]
   │                                ^^^^^^^^^^^^ unmatched license allowance

advisories ok, licenses ok
```

Signed-off-by: David Bernard <david.bernard.31@gmail.com>