### PR TITLE
chore: prepare release 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The SDK can be used to create CDEvents and send them as CloudEvents, as well as 
 Import the modules in your code
 
 ```toml
-cdevents = "0.1.0"
+cdevents-sdk = "0.1.0"
 ```
 
 To send a CDEvent as CloudEvent:

--- a/cdevents-sdk/CHANGELOG.md
+++ b/cdevents-sdk/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/cdevents/sdk-rust/releases/tag/cdevents-sdk-v0.1.0) - 2024-09-01
+
+### Added
+- add support for cdevents 0.4 ([#24](https://github.com/cdevents/sdk-rust/pull/24))
+- [**breaking**] add support for mulitple version of cdevents' specifications  ([#19](https://github.com/cdevents/sdk-rust/pull/19))
+- *(testkit)* provide proptest 's arbitraies to generate samples
+- string enum are defined as rust Enum
+- enforce mutation to only create coherente cdevents (type match subject.content)
+- introduce support for cloudevents
+- add support for `PartialEq`, `Eq` on `CDEvent`, use wrapper for `Uri` and `UriReference`
+- use more precise type for uri & datetime than String
+- use the same Subject struct for every event and an enum on Content
+
+### Fixed
+- enforce non-empty string for `id` and hardcode mapping between context.type and subject.type
+- use the `context.type` (instead of `$id`) to define the module name
+
+### Other
+- link README to top README
+- *(deps)* update fluent-uri requirement from 0.1 to 0.2 ([#31](https://github.com/cdevents/sdk-rust/pull/31))
+- *(deps)* update rstest requirement from 0.18 to 0.21 ([#27](https://github.com/cdevents/sdk-rust/pull/27))
+- *(deps)* update boon requirement from 0.5 to 0.6 ([#26](https://github.com/cdevents/sdk-rust/pull/26))
+- *(deps)* update proptest-derive requirement from 0.4 to 0.5 ([#29](https://github.com/cdevents/sdk-rust/pull/29))
+- change clipy configuration to support workspace and features
+- add test to validate against jsonschema: examples (from spec), generated samples
+- reformat Cargo.toml
+- update typo, remove commented code, move comments,... apply review suggestion
+- setup ci & linters
+- reformat
+- apply some recommendation from clippy
+- enable deny_unknown_fields
+- *(deps)* remove useless "serde_with"
+- replace generation of json object by named types for Subjects content
+- rename crates `cdevents` into `cdevents-sdk`

--- a/cdevents-sdk/Cargo.toml
+++ b/cdevents-sdk/Cargo.toml
@@ -8,6 +8,7 @@ publish = true
 repository.workspace = true
 rust-version.workspace = true
 description = "A Rust SDK for CDEvents"
+readme = "README.md"
 
 [dependencies]
 cloudevents-sdk = { version = "0.7", optional = true, default-features = false }

--- a/cdevents-sdk/README.md
+++ b/cdevents-sdk/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/cdevents-sdk/src/lib.rs
+++ b/cdevents-sdk/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 //#![warn(missing_docs)]
 // TODO remove unwrap(), expect(...)
 // TODO reduce clone()


### PR DESCRIPTION
This branch will be merge without squash as the tag 0.1.0 was put on it due to:

- protection on main branch (I could not push on it release change,...)
- restriction on github actions that doesn't allow to properly setup the release flow with release-plz,...