### PR TITLE
Add Plumber security scan and harden workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           submodules: "true"
-      - uses: mozilla-actions/sccache-action@v0.0.10
-      - uses: jdx/mise-action@v4
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
         with:
           # version 2025.5.11, a symlink is created for rust setup
           # without cache, missing components are installed

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Check Commit Lint
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           # Fail the check only when the Plumber Score drops below C.
           min-score: "C"
-          # score-push publishes a public A-E score badge to the hosted
-          # score service. Kept disabled here; see the PR description for
-          # the trade-offs before turning it on.
-          score-push: false
+          # Publish this repository's Plumber Score to the hosted score
+          # service so the README badge stays up to date. This makes the
+          # repository name and its score public.
+          score-push: true

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -4,7 +4,8 @@ permissions:
   contents: read
   # To upload the SARIF report to the Security tab
   security-events: write
-  # id-token: write  # required only when score-push is enabled (see PR description)
+  # To publish the Plumber Score via OIDC (score-push, see below)
+  id-token: write
 
 on:
   push:

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,35 @@
+name: plumber
+
+permissions:
+  contents: read
+  # To upload the SARIF report to the Security tab
+  security-events: write
+  # id-token: write  # required only when score-push is enabled (see PR description)
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan CI/CD workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Run Plumber
+        uses: getplumber/plumber@87ca135cc4566ba8e9065ea95b5d897232cdb208 # v0.4.16
+        with:
+          # Fail the check only when the Plumber Score drops below C.
+          min-score: "C"
+          # score-push publishes a public A-E score badge to the hosted
+          # score service. Kept disabled here; see the PR description for
+          # the trade-offs before turning it on.
+          score-push: false

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,12 +24,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: mozilla-actions/sccache-action@v0.0.10
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: release-plz/action@v0.5
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5
         with:
           command: release
         env:
@@ -50,12 +52,14 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: mozilla-actions/sccache-action@v0.0.10
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: release-plz/action@v0.5
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5
         with:
           command: release-pr
         env:

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,174 @@
+# Plumber configuration for the sdk-rust repository.
+# Based on Plumber's built-in defaults (github provider only); every control
+# is listed explicitly so none is silently disabled. The only customization is
+# the trustedGithubActions list below, which allowlists the third-party actions
+# this project already relies on.
+version: "2.0"
+github:
+  controls:
+    containerImageMustNotUseForbiddenTags:
+      enabled: true
+      tags:
+      - latest
+      - dev
+      - development
+      - staging
+      - main
+      - master
+      containerImagesMustBePinnedByDigest: true
+    branchMustBeProtected:
+      enabled: true
+      namePatterns:
+      - main
+      - master
+      - release/*
+      - production
+      - dev
+      defaultMustBeProtected: true
+      allowForcePush: false
+      # This project does not use a CODEOWNERS-based review process, so
+      # code owner approval is not part of its branch protection policy.
+      codeOwnerApprovalRequired: false
+    externalRefsMustNotCollide:
+      enabled: true
+    pipelineMustNotEnableDebugTrace:
+      enabled: true
+      forbiddenVariables:
+      - ACTIONS_STEP_DEBUG
+      - ACTIONS_RUNNER_DEBUG
+    securityJobsMustNotBeWeakened:
+      enabled: true
+      securityJobPatterns:
+      - '*codeql*'
+      - '*dependency-review*'
+      - '*trufflehog*'
+      - '*gitleaks*'
+      - '*osv-scanner*'
+      - '*-sast'
+      - '*-sast-*'
+      - '*-scan'
+      - '*scan*'
+      - '*-security'
+      - '*-security-*'
+      - '*-audit'
+      - '*-audit-*'
+      allowFailureMustBeFalse:
+        enabled: true
+      rulesMustNotBeRedefined:
+        enabled: true
+      whenMustNotBeManual:
+        enabled: true
+    pipelineMustNotExecuteUnverifiedScripts:
+      enabled: true
+    pipelineMustNotUseDockerInDocker:
+      enabled: true
+      detectInsecureDaemon: true
+    actionsMustBePinnedByCommitSha:
+      enabled: true
+      trustedOwners:
+      - actions
+      - github
+    githubActionMustComeFromAuthorizedSources:
+      enabled: true
+      trustGithubOfficialActions: true
+      trustSameOrgActions: true
+      trustedGithubActions:
+      - getplumber/plumber
+      - anthropics/claude-code-action
+      - docker/setup-qemu-action
+      - docker/setup-buildx-action
+      - docker/login-action
+      - docker/metadata-action
+      - docker/build-push-action
+      - ossf/scorecard-action
+      - anchore/scan-action
+      # Actions used by this repository's own workflows.
+      - jdx/mise-action
+      - mozilla-actions/sccache-action
+      - wagoid/commitlint-github-action
+      - release-plz/action
+      - dtolnay/rust-toolchain
+    workflowMustNotInjectUserInputInScripts:
+      enabled: true
+    workflowMustNotWriteUntrustedContentToGitHubEnv:
+      enabled: true
+    workflowMustNotUseDangerousTriggers:
+      enabled: true
+    pullRequestTargetMustNotCheckoutHead:
+      enabled: true
+    workflowsMustDeclarePermissions:
+      enabled: true
+    reusableWorkflowsMustNotInheritSecrets:
+      enabled: true
+    workflowMustNotExportEntireSecretsContext:
+      enabled: true
+    workflowMustNotGrantPermissionsWriteAll:
+      enabled: true
+    actionsMustNotBeArchived:
+      enabled: true
+    actionRefsMustExistUpstream:
+      enabled: true
+    actionsMustNotCarryKnownCVEs:
+      enabled: true
+    actionsMustNotExecuteMutableRemoteCode:
+      enabled: true
+    releaseWorkflowsMustNotRestoreUntrustedCache:
+      enabled: true
+      publishActions:
+      - pypa/gh-action-pypi-publish
+      - JS-DevTools/npm-publish
+      - gradle/publish-plugin
+      - softprops/action-gh-release
+      - ncipollo/release-action
+      - goreleaser/goreleaser-action
+      - crazy-max/ghaction-docker-buildx
+      - changesets/action
+      cacheActions:
+      - action: actions/cache
+        mode: always
+      - action: actions/cache/restore
+        mode: always
+      - action: Swatinem/rust-cache
+        mode: always
+      - action: actions/setup-go
+        mode: default
+        disableInput: cache
+        disableValue: false
+      - action: gradle/actions/setup-gradle
+        mode: default
+        disableInput: cache-disabled
+        disableValue: true
+      - action: actions/setup-node
+        mode: opt-in
+        enableInput: cache
+      - action: actions/setup-python
+        mode: opt-in
+        enableInput: cache
+      - action: actions/setup-java
+        mode: opt-in
+        enableInput: cache
+      - action: pnpm/action-setup
+        mode: opt-in
+        enableInput: cache
+      - action: docker/build-push-action
+        mode: opt-in
+        enableInput: cache-from
+        enableContains: type=gha
+      publishScriptPatterns:
+      - (?i)(npm|pnpm|yarn|bun)\s+publish
+      - (?i)cargo\s+publish
+      - (?i)twine\s+upload
+      - (?i)poetry\s+publish
+      - (?i)gh\s+release\s+create
+      - (?i)goreleaser\s+release
+      - (?i)semantic-release
+      - (?i)gradlew?\b[^\n]*\bpublish
+      - (?i)\bmvnw?\b[^\n]*\bdeploy\b
+      - (?i)dotnet\s+nuget\s+push
+      - (?i)gem\s+push
+      - (?i)docker\s+push
+      publishScriptExcludePatterns:
+      - (?i)--dry-run
+      - (?i)publishToMavenLocal
+    workflowMustIncludeRequiredActions:
+      enabled: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/cdevents-sdk.svg)](https://crates.io/crates/cdevents-sdk)
 [![docs.rs](https://img.shields.io/docsrs/cdevents-sdk)](https://docs.rs/cdevents-sdk)
 [![CI](https://github.com/cdevents/sdk-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/cdevents/sdk-rust/actions/workflows/ci.yml)
+[![Plumber Score](https://score.getplumber.io/github.com/cdevents/sdk-rust.svg)](https://score.getplumber.io/github.com/cdevents/sdk-rust)
 [![license](https://img.shields.io/crates/l/cdevents-sdk.svg)](LICENSE)
 
 Rust SDK to emit [CDEvents](https://cdevents.dev).


### PR DESCRIPTION
## What this does

This PR adds a workflow (`.github/workflows/plumber.yml`) that runs Plumber on every push and pull request to main. Plumber scans the repository's GitHub Actions workflows for CI/CD security issues and reports them to the Security tab.

Running the scan surfaced a set of pre-existing findings, so the PR also hardens the current workflows. Three commits cover the scan and the hardening:

1. **ci: add plumber security scan workflow** : the new workflow, with its own actions already pinned by SHA.
2. **ci: pin third-party actions to commit sha**: pin every third-party action in the ci, linter and release-plz workflows to a full commit SHA, keeping the version as a trailing comment (Dependabot can bump them).
3. **ci: add plumber config trusting existing action sources**: add `.plumber.yaml` that keeps every control enabled and allowlists the third-party actions this project already uses (`mise`, `sccache`, `commitlint`, `release-plz`, `rust-toolchain`). 

## Local scan result

With these changes the local run reports:

- Status: PASSED (score B, 77.5/100, required >= C)
- Passed Controls (20), Failed Controls (1)
- The gate is set to fail only below score C, so the check passes today. 

One finding is left as a follow-up on purpose:

- ISSUE-714: `dtolnay/rust-toolchain` runs the `rustup` installer from a moving ref. Pinning the action by SHA does not remove this, because the fetch happens inside the action itself. Fixing it means installing the toolchain from a pinned, checksum-verified source, which would change how releases install Rust. Left out of scope here. Let me know what you think about this and if you want to talk about how to fix it.


## ⚠️ About `score-push`: this PR publishes your plumber result

The last two commits enable `score-push` and add a Plumber Score badge to the README. When the workflow runs on main, it publishes this repository's result to the hosted service at `score.getplumber.io` over OIDC (no secret required).

This makes the repository name and its A to E score publicly visible, and the README badge reflects that score (the badge will remain `unknown` or `empty` until the first push to main on the upstream `cdevents/sdk-rust`).

**If you would rather not publish it:** just tell me and I will remove the 2 last commits from the PR. The scan and the hardening keep working either way. 